### PR TITLE
Create CE2 grammar segment training web app

### DIFF
--- a/data/phrases.json
+++ b/data/phrases.json
@@ -1,0 +1,482 @@
+[
+  {
+    "id": "n1-01",
+    "level": 1,
+    "text": "Le chat mange une souris.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Le chat" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "mange" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "une souris" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n1-02",
+    "level": 1,
+    "text": "Paul joue au ballon.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Paul" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "joue" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "au ballon" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n1-03",
+    "level": 1,
+    "text": "Marie lit un livre.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Marie" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "lit" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "un livre" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n1-04",
+    "level": 1,
+    "text": "Les oiseaux chantent une chanson.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Les oiseaux" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "chantent" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "une chanson" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n1-05",
+    "level": 1,
+    "text": "Le soleil brille dans le ciel.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Le soleil" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "brille" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "dans le ciel" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n1-06",
+    "level": 1,
+    "text": "Tu manges une pomme.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Tu" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "manges" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "une pomme" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n1-07",
+    "level": 1,
+    "text": "Nous regardons un film.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Nous" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "regardons" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "un film" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n1-08",
+    "level": 1,
+    "text": "La maîtresse explique la leçon.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "La maîtresse" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "explique" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "la leçon" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n1-09",
+    "level": 1,
+    "text": "Les lapins grignotent des carottes.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Les lapins" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "grignotent" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "des carottes" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n1-10",
+    "level": 1,
+    "text": "Léa dessine une maison.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Léa" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "dessine" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "une maison" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n1-11",
+    "level": 1,
+    "text": "Ils portent des sacs.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Ils" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "portent" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "des sacs" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n1-12",
+    "level": 1,
+    "text": "Le bébé touche son doudou.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Le bébé" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "touche" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "son doudou" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n2-01",
+    "level": 2,
+    "text": "Le petit garçon porte un grand sac.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Le petit garçon" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "porte" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "un grand sac" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n2-02",
+    "level": 2,
+    "text": "La vieille cloche sonne chaque matin.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "La vieille cloche" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "sonne" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "chaque matin" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n2-03",
+    "level": 2,
+    "text": "Le jardinier arrose les fleurs rouges.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Le jardinier" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "arrose" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "les fleurs rouges" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n2-04",
+    "level": 2,
+    "text": "Nous ne trouvons pas la clé.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Nous" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "ne trouvons pas" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "la clé" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n2-05",
+    "level": 2,
+    "text": "Les élèves rangent leurs cahiers bleus.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Les élèves" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "rangent" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "leurs cahiers bleus" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n2-06",
+    "level": 2,
+    "text": "Cette fillette tient une poupée douce.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Cette fillette" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "tient" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "une poupée douce" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n2-07",
+    "level": 2,
+    "text": "Le chaton noir chasse une boule de laine.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Le chaton noir" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "chasse" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "une boule de laine" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n2-08",
+    "level": 2,
+    "text": "Vous entendez un bruit étrange.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Vous" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "entendez" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "un bruit étrange" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n2-09",
+    "level": 2,
+    "text": "Mon oncle prépare une soupe chaude.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Mon oncle" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "prépare" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "une soupe chaude" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n2-10",
+    "level": 2,
+    "text": "La rivière traverse un petit village.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "La rivière" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "traverse" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "un petit village" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n2-11",
+    "level": 2,
+    "text": "Ces oiseaux ne quittent pas le nid.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Ces oiseaux" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "ne quittent pas" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "le nid" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n2-12",
+    "level": 2,
+    "text": "Les amies partagent un goûter sucré.",
+    "parts": [
+      { "type": "segment", "role": "GS", "text": "Les amies" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "partagent" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "un goûter sucré" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n3-01",
+    "level": 3,
+    "text": "Le matin, la brume enveloppe la vallée paisible.",
+    "parts": [
+      { "type": "text", "text": "Le matin, " },
+      { "type": "segment", "role": "GS", "text": "la brume" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "enveloppe" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "la vallée paisible" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n3-02",
+    "level": 3,
+    "text": "Sous la pluie, les coureurs accélèrent le rythme.",
+    "parts": [
+      { "type": "text", "text": "Sous la pluie, " },
+      { "type": "segment", "role": "GS", "text": "les coureurs" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "accélèrent" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "le rythme" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n3-03",
+    "level": 3,
+    "text": "Dans le grenier sombre, une araignée tisse sa toile.",
+    "parts": [
+      { "type": "text", "text": "Dans le grenier sombre, " },
+      { "type": "segment", "role": "GS", "text": "une araignée" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "tisse" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "sa toile" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n3-04",
+    "level": 3,
+    "text": "Autour du feu, les amis racontent une histoire mystérieuse.",
+    "parts": [
+      { "type": "text", "text": "Autour du feu, " },
+      { "type": "segment", "role": "GS", "text": "les amis" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "racontent" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "une histoire mystérieuse" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n3-05",
+    "level": 3,
+    "text": "Le soir venu, la chouette observe la clairière silencieuse.",
+    "parts": [
+      { "type": "text", "text": "Le soir venu, " },
+      { "type": "segment", "role": "GS", "text": "la chouette" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "observe" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "la clairière silencieuse" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n3-06",
+    "level": 3,
+    "text": "Près de la rivière, le castor construit un barrage solide.",
+    "parts": [
+      { "type": "text", "text": "Près de la rivière, " },
+      { "type": "segment", "role": "GS", "text": "le castor" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "construit" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "un barrage solide" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n3-07",
+    "level": 3,
+    "text": "Les volets fermés, la maison respire une odeur de pain chaud.",
+    "parts": [
+      { "type": "text", "text": "Les volets fermés, " },
+      { "type": "segment", "role": "GS", "text": "la maison" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "respire" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "une odeur de pain chaud" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n3-08",
+    "level": 3,
+    "text": "Au loin, les cloches annoncent la fête du village.",
+    "parts": [
+      { "type": "text", "text": "Au loin, " },
+      { "type": "segment", "role": "GS", "text": "les cloches" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "annoncent" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "la fête du village" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n3-09",
+    "level": 3,
+    "text": "Après le repas, les enfants découpent des formes colorées.",
+    "parts": [
+      { "type": "text", "text": "Après le repas, " },
+      { "type": "segment", "role": "GS", "text": "les enfants" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "découpent" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "des formes colorées" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n3-10",
+    "level": 3,
+    "text": "Dans la cour, une fillette observe les nuages mouvants.",
+    "parts": [
+      { "type": "text", "text": "Dans la cour, " },
+      { "type": "segment", "role": "GS", "text": "une fillette" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "observe" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "les nuages mouvants" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n3-11",
+    "level": 3,
+    "text": "Au marché du village, les marchands proposent des fruits rares.",
+    "parts": [
+      { "type": "text", "text": "Au marché du village, " },
+      { "type": "segment", "role": "GS", "text": "les marchands" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "proposent" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "des fruits rares" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n3-12",
+    "level": 3,
+    "text": "Près du port, les pêcheurs réparent leurs filets usés.",
+    "parts": [
+      { "type": "text", "text": "Près du port, " },
+      { "type": "segment", "role": "GS", "text": "les pêcheurs" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "réparent" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "leurs filets usés" },
+      { "type": "text", "text": "." }
+    ]
+  }
+]

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -1,0 +1,24 @@
+# DEV
+
+## Objectif du repo
+Entraînement CE2 au repérage du groupe sujet (GS), du verbe noyau du groupe verbal et d'un groupe nominal complément.
+
+## Structure
+- `/public` : assets statiques (pictogrammes GS / Verbe / GN).
+- `/src` : logique UI et composants (fichiers JavaScript et feuilles de style).
+- `/data/phrases.json` : phrases annotées avec les segments interactifs.
+- `/docs` : documentation (ce fichier et LATER.md).
+
+## Lancer en local
+1. Ouvrir `index.html` dans un navigateur moderne (desktop, mobile ou tablette).
+2. Aucun serveur n'est requis, tout est statique.
+
+## Conventions
+- Rôles : utiliser les libellés `GS`, `VERBE`, `GN` pour les segments et les clés de données.
+- Format de données : chaque entrée dans `phrases.json` contient `id`, `level`, `text` et un tableau `parts` avec des objets `{ type: 'text' | 'segment', role?, text }`.
+- Messages de commit : courts et descriptifs (ex : `feat: ajouter mode drag tactile`).
+
+## Itération
+- Ajouter 5 à 10 phrases tests supplémentaires par niveau avant d'élargir le périmètre.
+- Vérifier le comportement tactile (tablette/smartphone) à chaque ajout d'interaction.
+- Garder les feedbacks textuels courts et positifs.

--- a/docs/LATER.md
+++ b/docs/LATER.md
@@ -1,0 +1,8 @@
+# LATER
+
+- Ajout de phrases par l'utilisateur (enseignant ou parent).
+- Stockage cloud et authentification (ex. Supabase, Firebase).
+- Mode défi, historique détaillé, export des résultats.
+- Gestion multi-utilisateurs ou profils différenciés.
+- Tableau de bord avancé avec statistiques par compétence.
+- Extension à d'autres temps verbaux ou accords complexes.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="fr-FR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Repérer GS, Verbe et GN - CE2</title>
+    <link rel="stylesheet" href="src/styles.css" />
+  </head>
+  <body>
+    <header class="app-header" role="banner">
+      <h1>Repérer GS, Verbe et GN</h1>
+      <p class="tagline">Entraînement CE2 • phrase par phrase</p>
+    </header>
+    <main id="app" class="app" role="main">
+      <section id="screen-home" class="screen active" aria-label="Accueil">
+        <div class="card">
+          <h2>Choisis ton niveau</h2>
+          <div class="level-grid" role="group" aria-label="Niveaux">
+            <button class="level-btn" data-level="1">Niveau 1</button>
+            <button class="level-btn" data-level="2">Niveau 2</button>
+            <button class="level-btn" data-level="3">Niveau 3</button>
+            <button class="level-btn" data-level="all">Révision libre</button>
+          </div>
+          <div class="resume" id="resume-panel" aria-live="polite"></div>
+        </div>
+      </section>
+      <section id="screen-exercise" class="screen" aria-label="Exercice">
+        <div class="top-bar">
+          <button id="back-home" class="ghost">← Accueil</button>
+          <div class="scoreboard" aria-live="polite">
+            <span id="score-display">Score : 0</span>
+            <span id="streak-display">Série : 0</span>
+            <span id="best-display">Meilleur : 0</span>
+          </div>
+        </div>
+        <div class="card exercise-card">
+          <div class="exercise-header">
+            <div class="mode-switch" role="group" aria-label="Modes d'interaction">
+              <button class="mode-btn active" data-mode="highlight">Surlignage</button>
+              <button class="mode-btn" data-mode="drag">Drag &amp; Drop</button>
+            </div>
+            <div class="icon-legend" role="list">
+              <div role="listitem" class="legend-item" data-role="GS" tabindex="0">
+                <img src="public/pictos/subject.svg" alt="Sujet" />
+                <span>GS</span>
+              </div>
+              <div role="listitem" class="legend-item" data-role="VERBE" tabindex="0">
+                <img src="public/pictos/verb.svg" alt="Verbe" />
+                <span>Verbe</span>
+              </div>
+              <div role="listitem" class="legend-item" data-role="GN" tabindex="0">
+                <img src="public/pictos/group.svg" alt="Groupe nominal" />
+                <span>GN</span>
+              </div>
+            </div>
+          </div>
+          <div class="phrase-zone" aria-live="polite">
+            <p id="phrase-text" class="phrase" data-mode="highlight"></p>
+          </div>
+          <div class="drag-area" aria-hidden="true">
+            <div class="drag-label" data-role="GS" draggable="false" aria-label="Étiquette Sujet">GS</div>
+            <div class="drag-label" data-role="VERBE" draggable="false" aria-label="Étiquette Verbe">Verbe</div>
+            <div class="drag-label" data-role="GN" draggable="false" aria-label="Étiquette Groupe nominal">GN</div>
+          </div>
+          <div class="help-text" id="help-text" aria-live="assertive"></div>
+          <div class="controls">
+            <button id="help-btn" class="ghost">Indice</button>
+            <button id="validate-btn" class="primary">Valider</button>
+            <button id="next-btn" class="secondary" disabled>Suivant</button>
+          </div>
+        </div>
+      </section>
+      <div id="toast" role="status" aria-live="polite" hidden></div>
+    </main>
+    <footer class="app-footer" role="contentinfo">
+      <small>Progression enregistrée sur cet appareil.</small>
+    </footer>
+    <script type="module" src="src/main.js"></script>
+  </body>
+</html>

--- a/public/pictos/group.svg
+++ b/public/pictos/group.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-hidden="true">
+  <rect x="12" y="18" width="40" height="28" rx="6" fill="#27ae60" />
+  <rect x="20" y="26" width="24" height="12" rx="3" fill="#ffffff" opacity="0.6" />
+</svg>

--- a/public/pictos/subject.svg
+++ b/public/pictos/subject.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-hidden="true">
+  <circle cx="32" cy="24" r="14" fill="#4a90e2" />
+  <rect x="18" y="36" width="28" height="20" rx="10" fill="#4a90e2" />
+</svg>

--- a/public/pictos/verb.svg
+++ b/public/pictos/verb.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-hidden="true">
+  <path d="M18 46 L28 18 L36 34 L46 18 L36 46 Z" fill="#e67e22" />
+</svg>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,402 @@
+import { loadProgress, recordResult, updateLastLevel } from './storage.js';
+
+const ROLE_ORDER = ['GS', 'VERBE', 'GN'];
+const ROLE_MESSAGES = {
+  GS: 'Le sujet indique qui fait l\'action.',
+  VERBE: 'Le verbe est le mot qui se conjugue.',
+  GN: 'Le groupe nominal complète ou précise l\'action.'
+};
+
+const appState = {
+  phrases: [],
+  queue: [],
+  currentIndex: 0,
+  currentPhrase: null,
+  assignments: new Map(),
+  progress: loadProgress(),
+  activeRole: 'GS',
+  mode: 'highlight',
+  hasValidated: false
+};
+
+const elements = {
+  screens: {
+    home: document.getElementById('screen-home'),
+    exercise: document.getElementById('screen-exercise')
+  },
+  levelButtons: Array.from(document.querySelectorAll('.level-btn')),
+  resumePanel: document.getElementById('resume-panel'),
+  backHome: document.getElementById('back-home'),
+  scoreDisplay: document.getElementById('score-display'),
+  streakDisplay: document.getElementById('streak-display'),
+  bestDisplay: document.getElementById('best-display'),
+  phraseText: document.getElementById('phrase-text'),
+  dragArea: document.querySelector('.drag-area'),
+  dragLabels: Array.from(document.querySelectorAll('.drag-label')),
+  modeButtons: Array.from(document.querySelectorAll('.mode-btn')),
+  legendItems: Array.from(document.querySelectorAll('.legend-item[data-role]')),
+  helpBtn: document.getElementById('help-btn'),
+  validateBtn: document.getElementById('validate-btn'),
+  nextBtn: document.getElementById('next-btn'),
+  helpText: document.getElementById('help-text'),
+  toast: document.getElementById('toast')
+};
+
+let dragState = null;
+
+async function init() {
+  await loadData();
+  bindEvents();
+  setActiveRole(appState.activeRole);
+  renderResume();
+  updateScoreboard();
+  const { lastLevel } = appState.progress;
+  if (lastLevel) {
+    const label = lastLevel === 'all' ? 'Révision libre' : `Niveau ${lastLevel}`;
+    elements.resumePanel.textContent += ` Dernier niveau : ${label}.`;
+  }
+}
+
+async function loadData() {
+  try {
+    const response = await fetch('data/phrases.json');
+    const data = await response.json();
+    appState.phrases = data;
+  } catch (error) {
+    console.error('Impossible de charger les phrases', error);
+    elements.resumePanel.textContent = 'Erreur de chargement des données. Réessaie plus tard.';
+  }
+}
+
+function bindEvents() {
+  elements.levelButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      startSession(button.dataset.level);
+    });
+  });
+
+  elements.backHome.addEventListener('click', () => {
+    swapScreen('home');
+    renderResume();
+  });
+
+  elements.modeButtons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      if (appState.mode === btn.dataset.mode) return;
+      switchMode(btn.dataset.mode);
+    });
+  });
+
+  elements.legendItems.forEach((item) => {
+    item.addEventListener('click', () => setActiveRole(item.dataset.role));
+    item.addEventListener('keypress', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        setActiveRole(item.dataset.role);
+      }
+    });
+  });
+
+  elements.helpBtn.addEventListener('click', revealHint);
+  elements.validateBtn.addEventListener('click', onValidate);
+  elements.nextBtn.addEventListener('click', () => {
+    loadNextPhrase();
+  });
+
+  elements.dragLabels.forEach((label) => {
+    label.addEventListener('pointerdown', handleDragStart);
+    label.addEventListener('pointermove', handleDragMove);
+    label.addEventListener('pointerup', handleDragEnd);
+    label.addEventListener('pointercancel', handleDragEnd);
+  });
+}
+
+function startSession(level) {
+  const levelFilter = level === 'all' ? null : Number(level);
+  const available = levelFilter
+    ? appState.phrases.filter((item) => item.level === levelFilter)
+    : [...appState.phrases];
+  if (!available.length) {
+    showToast('Aucune phrase disponible pour ce niveau.');
+    return;
+  }
+  appState.queue = shuffleArray(available);
+  appState.currentIndex = 0;
+  appState.currentPhrase = null;
+  appState.assignments = new Map();
+  appState.hasValidated = false;
+  swapScreen('exercise');
+  switchMode('highlight');
+  setActiveRole('GS');
+  appState.progress = updateLastLevel(appState.progress, level);
+  loadNextPhrase();
+}
+
+function swapScreen(target) {
+  Object.entries(elements.screens).forEach(([key, section]) => {
+    section.classList.toggle('active', key === target);
+  });
+}
+
+function renderResume() {
+  const { totalScore, bestScore, streak, recentPhrases } = appState.progress;
+  const lines = [
+    `Score enregistré : ${totalScore}`,
+    `Meilleur score : ${bestScore}`,
+    `Série actuelle : ${streak}`
+  ];
+  if (recentPhrases && recentPhrases.length) {
+    lines.push(`Dernières phrases : ${recentPhrases.slice(0, 5).join(', ')}`);
+  }
+  elements.resumePanel.textContent = lines.join(' • ');
+}
+
+function switchMode(mode) {
+  appState.mode = mode;
+  elements.modeButtons.forEach((btn) => {
+    btn.classList.toggle('active', btn.dataset.mode === mode);
+  });
+  elements.phraseText.dataset.mode = mode;
+  const dragVisible = mode === 'drag';
+  elements.dragArea.setAttribute('aria-hidden', dragVisible ? 'false' : 'true');
+  elements.dragArea.style.display = dragVisible ? 'flex' : 'none';
+  elements.helpText.textContent = '';
+  resetAssignments(false);
+}
+
+function setActiveRole(role) {
+  appState.activeRole = role;
+  elements.legendItems.forEach((item) => {
+    item.classList.toggle('active', item.dataset.role === role);
+  });
+}
+
+function loadNextPhrase() {
+  if (!appState.queue.length) return;
+  const phrase = appState.queue[appState.currentIndex % appState.queue.length];
+  appState.currentPhrase = phrase;
+  appState.currentIndex += 1;
+  appState.assignments = new Map();
+  appState.hasValidated = false;
+  elements.helpText.textContent = '';
+  elements.validateBtn.disabled = false;
+  elements.nextBtn.disabled = true;
+  renderPhrase(phrase);
+}
+
+function renderPhrase(phrase) {
+  elements.phraseText.innerHTML = '';
+  let segmentIndex = 0;
+  phrase.parts.forEach((part) => {
+    if (part.type === 'text') {
+      const textNode = document.createTextNode(part.text);
+      elements.phraseText.append(textNode);
+      return;
+    }
+    const span = document.createElement('span');
+    span.textContent = part.text;
+    span.className = 'segment';
+    span.dataset.correctRole = part.role;
+    span.dataset.segmentIndex = String(segmentIndex);
+    span.dataset.displayRole = '';
+    span.setAttribute('tabindex', '0');
+    span.setAttribute('role', 'button');
+    span.setAttribute('aria-pressed', 'false');
+    span.addEventListener('click', () => onSegmentInteract(segmentIndex));
+    span.addEventListener('keypress', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        onSegmentInteract(segmentIndex);
+      }
+    });
+    elements.phraseText.append(span);
+    segmentIndex += 1;
+  });
+}
+
+function onSegmentInteract(index) {
+  if (appState.mode !== 'highlight' || appState.hasValidated) return;
+  const role = appState.activeRole;
+  assignRole(index, role);
+}
+
+function assignRole(index, role) {
+  const segment = getSegmentElement(index);
+  if (!segment) return;
+  appState.assignments.set(index, role);
+  segment.dataset.displayRole = role;
+  segment.classList.add('assigned');
+  segment.classList.remove('incorrect', 'correct', 'hint');
+  segment.setAttribute('aria-pressed', 'true');
+}
+
+function getSegmentElement(index) {
+  return elements.phraseText.querySelector(`.segment[data-segment-index="${index}"]`);
+}
+
+function revealHint() {
+  if (!appState.currentPhrase) return;
+  const verbSegment = elements.phraseText.querySelector(
+    '.segment[data-correct-role="VERBE"]'
+  );
+  if (!verbSegment) return;
+  verbSegment.classList.add('hint');
+  verbSegment.dataset.displayRole = 'VERBE';
+  elements.helpText.textContent = 'Indice : le verbe est déjà mis en avant.';
+}
+
+function onValidate() {
+  if (appState.hasValidated) return;
+  const segments = Array.from(elements.phraseText.querySelectorAll('.segment'));
+  if (segments.length !== ROLE_ORDER.length) {
+    console.warn('Phrase inattendue : nombre de segments différent de 3.');
+  }
+  const missing = segments.filter((segment) => !appState.assignments.has(Number(segment.dataset.segmentIndex)));
+  if (missing.length) {
+    elements.helpText.textContent = 'Sélectionne chaque segment avant de valider.';
+    return;
+  }
+
+  let correctCount = 0;
+  const feedbackRoles = new Set();
+  segments.forEach((segment) => {
+    const idx = Number(segment.dataset.segmentIndex);
+    const expected = segment.dataset.correctRole;
+    const given = appState.assignments.get(idx);
+    segment.classList.remove('assigned', 'hint');
+    if (given === expected) {
+      correctCount += 1;
+      segment.classList.add('correct');
+      segment.dataset.displayRole = expected;
+    } else {
+      segment.classList.add('incorrect');
+      segment.dataset.displayRole = given;
+      feedbackRoles.add(expected);
+    }
+  });
+
+  const stars = correctCount;
+  const deltaScore = correctCount;
+  appState.progress = recordResult(
+    appState.progress,
+    appState.currentPhrase.id,
+    deltaScore,
+    stars
+  );
+  updateScoreboard();
+  const messages = [];
+  if (stars === 3) {
+    messages.push('Bravo ! 3 étoiles ✨');
+  } else if (stars === 0) {
+    messages.push('Essaie encore, tu vas y arriver !');
+  } else {
+    messages.push(`${stars} étoile${stars > 1 ? 's' : ''} gagnée${stars > 1 ? 's' : ''}.`);
+  }
+  feedbackRoles.forEach((role) => {
+    messages.push(ROLE_MESSAGES[role]);
+  });
+  showToast(messages.join(' '));
+  elements.helpText.textContent = messages.slice(1).join(' ');
+  elements.nextBtn.disabled = false;
+  elements.validateBtn.disabled = true;
+  appState.hasValidated = true;
+}
+
+function resetAssignments(clearHints = true) {
+  appState.assignments.clear();
+  const segments = Array.from(elements.phraseText.querySelectorAll('.segment'));
+  segments.forEach((segment) => {
+    segment.classList.remove('assigned', 'correct', 'incorrect');
+    if (clearHints) {
+      segment.classList.remove('hint');
+    }
+    segment.dataset.displayRole = '';
+    segment.setAttribute('aria-pressed', 'false');
+  });
+  appState.hasValidated = false;
+  elements.validateBtn.disabled = false;
+  elements.nextBtn.disabled = true;
+  elements.helpText.textContent = '';
+}
+
+function handleDragStart(event) {
+  if (appState.mode !== 'drag') return;
+  event.preventDefault();
+  const label = event.currentTarget;
+  label.setPointerCapture(event.pointerId);
+  const ghost = createGhost(label, event.clientX, event.clientY);
+  dragState = {
+    pointerId: event.pointerId,
+    role: label.dataset.role,
+    ghost,
+    source: label
+  };
+  label.classList.add('dragging');
+}
+
+function handleDragMove(event) {
+  if (!dragState || event.pointerId !== dragState.pointerId) return;
+  event.preventDefault();
+  moveGhost(dragState.ghost, event.clientX, event.clientY);
+}
+
+function handleDragEnd(event) {
+  if (!dragState || event.pointerId !== dragState.pointerId) return;
+  const { ghost, role, source } = dragState;
+  source.classList.remove('dragging');
+  source.releasePointerCapture(event.pointerId);
+  moveGhost(ghost, event.clientX, event.clientY);
+  ghost.remove();
+  const dropTarget = document.elementFromPoint(event.clientX, event.clientY);
+  if (dropTarget && dropTarget.classList.contains('segment') && !appState.hasValidated) {
+    const idx = Number(dropTarget.dataset.segmentIndex);
+    assignRole(idx, role);
+  }
+  dragState = null;
+}
+
+function createGhost(label, clientX, clientY) {
+  const ghost = label.cloneNode(true);
+  ghost.classList.add('dragging');
+  ghost.style.position = 'fixed';
+  ghost.style.pointerEvents = 'none';
+  ghost.style.zIndex = '2000';
+  document.body.appendChild(ghost);
+  moveGhost(ghost, clientX, clientY);
+  return ghost;
+}
+
+function moveGhost(ghost, clientX, clientY) {
+  ghost.style.left = `${clientX}px`;
+  ghost.style.top = `${clientY}px`;
+  ghost.style.transform = 'translate(-50%, -50%) scale(1.02)';
+}
+
+function updateScoreboard() {
+  const { totalScore = 0, streak = 0, bestScore = 0 } = appState.progress;
+  elements.scoreDisplay.textContent = `Score : ${totalScore}`;
+  elements.streakDisplay.textContent = `Série : ${streak}`;
+  elements.bestDisplay.textContent = `Meilleur : ${bestScore}`;
+}
+
+function showToast(message) {
+  if (!message) return;
+  elements.toast.textContent = message;
+  elements.toast.hidden = false;
+  elements.toast.classList.add('show');
+  setTimeout(() => {
+    elements.toast.classList.remove('show');
+    elements.toast.hidden = true;
+  }, 2400);
+}
+
+function shuffleArray(arr) {
+  const copy = [...arr];
+  for (let i = copy.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+init();

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,55 @@
+const STORAGE_KEY = 'ce2-grammaire-progress';
+
+const defaultState = {
+  totalScore: 0,
+  bestScore: 0,
+  streak: 0,
+  lastLevel: null,
+  recentPhrases: []
+};
+
+export function loadProgress() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return { ...defaultState };
+    }
+    const parsed = JSON.parse(raw);
+    return { ...defaultState, ...parsed };
+  } catch (error) {
+    console.warn('Impossible de lire la progression :', error);
+    return { ...defaultState };
+  }
+}
+
+export function saveProgress(state) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (error) {
+    console.warn('Impossible d\'enregistrer la progression :', error);
+  }
+}
+
+export function recordResult(progress, phraseId, deltaScore, stars) {
+  const next = { ...progress };
+  next.totalScore = Math.max(0, next.totalScore + deltaScore);
+  next.bestScore = Math.max(next.bestScore || 0, next.totalScore);
+  if (stars === 3) {
+    next.streak = (next.streak || 0) + 1;
+  } else if (stars === 0) {
+    next.streak = 0;
+  } else {
+    next.streak = Math.max((next.streak || 0) - 1, 0);
+  }
+  next.recentPhrases = [phraseId, ...(next.recentPhrases || [])]
+    .filter(Boolean)
+    .slice(0, 10);
+  saveProgress(next);
+  return next;
+}
+
+export function updateLastLevel(progress, level) {
+  const next = { ...progress, lastLevel: level };
+  saveProgress(next);
+  return next;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,395 @@
+:root {
+  color-scheme: light;
+  --font-base: "Montserrat", "Helvetica Neue", Arial, sans-serif;
+  --bg: #f8fafc;
+  --card: #ffffff;
+  --text: #1f2933;
+  --muted: #52606d;
+  --primary: #4a90e2;
+  --primary-dark: #2f7ad1;
+  --accent: #27ae60;
+  --warning: #e67e22;
+  --error: #d64545;
+  --radius: 14px;
+  --transition: 220ms ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-base);
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header,
+.app-footer {
+  text-align: center;
+  padding: 1.5rem 1rem;
+  background: transparent;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 4vw, 2.4rem);
+}
+
+.tagline {
+  margin: 0.2rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.app {
+  flex: 1;
+  width: min(960px, 94vw);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.screen {
+  display: none;
+}
+
+.screen.active {
+  display: block;
+}
+
+.card {
+  background: var(--card);
+  border-radius: var(--radius);
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.level-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+
+button {
+  font: inherit;
+  border: none;
+  border-radius: calc(var(--radius) / 1.6);
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  transition: transform var(--transition), background var(--transition), color var(--transition), box-shadow var(--transition);
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.level-btn {
+  background: #e3efff;
+  color: var(--primary-dark);
+  font-weight: 600;
+}
+
+.level-btn:hover,
+.level-btn:focus-visible {
+  background: var(--primary);
+  color: white;
+  transform: translateY(-2px);
+  box-shadow: 0 12px 20px rgba(74, 144, 226, 0.25);
+}
+
+.resume {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.top-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.ghost {
+  background: transparent;
+  border: 1px solid rgba(74, 144, 226, 0.35);
+  color: var(--primary-dark);
+}
+
+.primary {
+  background: var(--primary);
+  color: white;
+  font-weight: 600;
+}
+
+.primary:hover,
+.primary:focus-visible {
+  background: var(--primary-dark);
+}
+
+.secondary {
+  background: rgba(39, 174, 96, 0.15);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.exercise-card {
+  gap: 1.5rem;
+}
+
+.mode-switch {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.mode-btn {
+  background: rgba(82, 96, 109, 0.08);
+  font-weight: 600;
+}
+
+.mode-btn.active {
+  background: var(--primary);
+  color: white;
+  box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.16);
+}
+
+.icon-legend {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: var(--muted);
+  font-size: 0.95rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 999px;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: border var(--transition), background var(--transition), color var(--transition);
+}
+
+.legend-item img {
+  width: 28px;
+  height: 28px;
+}
+
+.legend-item:focus-visible {
+  outline: none;
+  border-color: rgba(74, 144, 226, 0.4);
+}
+
+.legend-item.active {
+  background: rgba(74, 144, 226, 0.12);
+  border-color: rgba(74, 144, 226, 0.6);
+  color: var(--primary-dark);
+}
+
+.phrase-zone {
+  background: rgba(74, 144, 226, 0.08);
+  border-radius: calc(var(--radius) / 1.2);
+  padding: 1.5rem;
+  min-height: 140px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.phrase {
+  font-size: clamp(1.1rem, 2.8vw, 1.6rem);
+  line-height: 1.6;
+  text-align: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  justify-content: center;
+}
+
+.segment {
+  position: relative;
+  padding: 0.15rem 0.35rem;
+  border-radius: 8px;
+  transition: background var(--transition), box-shadow var(--transition), transform var(--transition);
+}
+
+.segment[data-display-role="GS"] {
+  --segment-color: rgba(74, 144, 226, 0.25);
+  --segment-strong: #4a90e2;
+}
+
+.segment[data-display-role="VERBE"] {
+  --segment-color: rgba(230, 126, 34, 0.22);
+  --segment-strong: #e67e22;
+}
+
+.segment[data-display-role="GN"] {
+  --segment-color: rgba(39, 174, 96, 0.22);
+  --segment-strong: #27ae60;
+}
+
+.segment.assigned {
+  background: var(--segment-color);
+  box-shadow: 0 0 0 2px var(--segment-strong) inset;
+}
+
+.segment.hint {
+  background: rgba(74, 144, 226, 0.2);
+  box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.5) inset;
+}
+
+.segment.correct {
+  animation: pop var(--transition);
+  background: rgba(39, 174, 96, 0.25);
+  box-shadow: 0 0 0 2px var(--accent) inset;
+}
+
+.segment.incorrect {
+  animation: shake 260ms ease;
+  background: rgba(214, 69, 69, 0.15);
+  box-shadow: 0 0 0 2px var(--error) inset;
+}
+
+@keyframes pop {
+  from {
+    transform: scale(0.96);
+  }
+  to {
+    transform: scale(1);
+  }
+}
+
+@keyframes shake {
+  0% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-4px);
+  }
+  50% {
+    transform: translateX(4px);
+  }
+  75% {
+    transform: translateX(-3px);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
+.drag-area {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.drag-label {
+  min-width: 90px;
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  text-align: center;
+  font-weight: 600;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.9);
+  border: 2px solid rgba(82, 96, 109, 0.2);
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.1);
+  touch-action: none;
+  position: relative;
+}
+
+.drag-label.dragging {
+  opacity: 0.8;
+  box-shadow: 0 14px 24px rgba(74, 144, 226, 0.32);
+  background: var(--card);
+}
+
+.help-text {
+  min-height: 1.2rem;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.controls {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.scoreboard {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  font-weight: 600;
+}
+
+#toast {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--text);
+  color: white;
+  padding: 0.75rem 1.2rem;
+  border-radius: 999px;
+  box-shadow: 0 12px 22px rgba(15, 23, 42, 0.25);
+  font-size: 0.95rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition), transform var(--transition);
+}
+
+#toast.show {
+  opacity: 1;
+  transform: translate(-50%, -6px);
+}
+
+@media (max-width: 680px) {
+  .card {
+    padding: 1.3rem;
+  }
+
+  .icon-legend {
+    flex-wrap: wrap;
+  }
+
+  .phrase-zone {
+    padding: 1.1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    font-size: 16px;
+  }
+
+  .scoreboard {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .mode-switch {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .drag-label {
+    min-width: 80px;
+    font-size: 0.95rem;
+  }
+}


### PR DESCRIPTION
## Summary
- build a static responsive interface with level selection and dual interaction modes
- implement highlight and drag-and-drop exercises with scoring, streaks, hints, and localStorage persistence
- add a curated dataset of 36 annotated phrases plus project docs and pictograms

## Testing
- Manual QA: `python3 -m http.server 8000`


------
https://chatgpt.com/codex/tasks/task_e_68d9842a094c832399e86d573aa2781a