### PR TITLE
Refine drag-only gameplay and add new level

### DIFF
--- a/data/phrases.json
+++ b/data/phrases.json
@@ -478,5 +478,149 @@
       { "type": "segment", "role": "GN", "text": "leurs filets usés" },
       { "type": "text", "text": "." }
     ]
+  },
+  {
+    "id": "n4-01",
+    "level": 4,
+    "text": "Sous le ciel étoilé, les deux astronautes émerveillés observent la Terre bleue.",
+    "parts": [
+      { "type": "text", "text": "Sous le ciel étoilé, " },
+      {
+        "type": "segment",
+        "role": "GS",
+        "text": "les deux astronautes émerveillés"
+      },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "observent" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "la Terre bleue" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n4-02",
+    "level": 4,
+    "text": "Grâce à leur courage, les trois explorateurs silencieux franchissent la rivière glacée.",
+    "parts": [
+      { "type": "text", "text": "Grâce à leur courage, " },
+      {
+        "type": "segment",
+        "role": "GS",
+        "text": "les trois explorateurs silencieux"
+      },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "franchissent" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "la rivière glacée" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n4-03",
+    "level": 4,
+    "text": "Malgré le vent glacial, la grande montgolfière colorée emporte les voyageurs joyeux.",
+    "parts": [
+      { "type": "text", "text": "Malgré le vent glacial, " },
+      {
+        "type": "segment",
+        "role": "GS",
+        "text": "la grande montgolfière colorée"
+      },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "emporte" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "les voyageurs joyeux" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n4-04",
+    "level": 4,
+    "text": "Au milieu du désert doré, les caravanes patientes transportent des trésors précieux.",
+    "parts": [
+      { "type": "text", "text": "Au milieu du désert doré, " },
+      {
+        "type": "segment",
+        "role": "GS",
+        "text": "les caravanes patientes"
+      },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "transportent" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "des trésors précieux" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n4-05",
+    "level": 4,
+    "text": "Quand la cloche résonne, toute la classe attentive range ses cahiers illustrés.",
+    "parts": [
+      { "type": "text", "text": "Quand la cloche résonne, " },
+      {
+        "type": "segment",
+        "role": "GS",
+        "text": "toute la classe attentive"
+      },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "range" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "ses cahiers illustrés" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n4-06",
+    "level": 4,
+    "text": "À la tombée de la nuit, les lucioles lumineuses illuminent le sentier sinueux.",
+    "parts": [
+      { "type": "text", "text": "À la tombée de la nuit, " },
+      {
+        "type": "segment",
+        "role": "GS",
+        "text": "les lucioles lumineuses"
+      },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "illuminent" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "le sentier sinueux" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n4-07",
+    "level": 4,
+    "text": "Pendant l'orage, la vieille cabane tremblante protège les animaux abrités.",
+    "parts": [
+      { "type": "text", "text": "Pendant l'orage, " },
+      {
+        "type": "segment",
+        "role": "GS",
+        "text": "la vieille cabane tremblante"
+      },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "protège" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "les animaux abrités" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "n4-08",
+    "level": 4,
+    "text": "Dans la forêt enchantée, la chouette au plumage argenté surveille les petits aventuriers.",
+    "parts": [
+      { "type": "text", "text": "Dans la forêt enchantée, " },
+      {
+        "type": "segment",
+        "role": "GS",
+        "text": "la chouette au plumage argenté"
+      },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERBE", "text": "surveille" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "GN", "text": "les petits aventuriers" },
+      { "type": "text", "text": "." }
+    ]
   }
 ]

--- a/data/phrases.json
+++ b/data/phrases.json
@@ -1,625 +1,369 @@
 [
   {
-    "id": "n1-01",
+    "id": "l1-01",
     "level": 1,
-    "text": "Le chat mange une souris.",
+    "text": "Le chat dort.",
     "parts": [
-      { "type": "segment", "role": "GS", "text": "Le chat" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "Le chat" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "mange" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "une souris" },
+      { "type": "segment", "role": "VERB", "text": "dort" },
       { "type": "text", "text": "." }
     ]
   },
   {
-    "id": "n1-02",
+    "id": "l1-02",
     "level": 1,
-    "text": "Paul joue au ballon.",
+    "text": "Léo court vite.",
     "parts": [
-      { "type": "segment", "role": "GS", "text": "Paul" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "Léo" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "joue" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "au ballon" },
-      { "type": "text", "text": "." }
+      { "type": "segment", "role": "VERB", "text": "court" },
+      { "type": "text", "text": " vite." }
     ]
   },
   {
-    "id": "n1-03",
+    "id": "l1-03",
     "level": 1,
-    "text": "Marie lit un livre.",
+    "text": "Ils jouent.",
     "parts": [
-      { "type": "segment", "role": "GS", "text": "Marie" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "PRONOUN", "text": "Ils" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "lit" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "un livre" },
+      { "type": "segment", "role": "VERB", "text": "jouent" },
       { "type": "text", "text": "." }
     ]
   },
   {
-    "id": "n1-04",
+    "id": "l1-04",
     "level": 1,
-    "text": "Les oiseaux chantent une chanson.",
+    "text": "La pluie tombe.",
     "parts": [
-      { "type": "segment", "role": "GS", "text": "Les oiseaux" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "La pluie" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "chantent" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "une chanson" },
+      { "type": "segment", "role": "VERB", "text": "tombe" },
       { "type": "text", "text": "." }
     ]
   },
   {
-    "id": "n1-05",
+    "id": "l1-05",
     "level": 1,
-    "text": "Le soleil brille dans le ciel.",
+    "text": "Je ris.",
     "parts": [
-      { "type": "segment", "role": "GS", "text": "Le soleil" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "PRONOUN", "text": "Je" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "brille" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "dans le ciel" },
+      { "type": "segment", "role": "VERB", "text": "ris" },
       { "type": "text", "text": "." }
     ]
   },
   {
-    "id": "n1-06",
+    "id": "l1-06",
     "level": 1,
-    "text": "Tu manges une pomme.",
+    "text": "Le train arrive.",
     "parts": [
-      { "type": "segment", "role": "GS", "text": "Tu" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "Le train" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "manges" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "une pomme" },
+      { "type": "segment", "role": "VERB", "text": "arrive" },
       { "type": "text", "text": "." }
     ]
   },
   {
-    "id": "n1-07",
+    "id": "l1-07",
     "level": 1,
-    "text": "Nous regardons un film.",
+    "text": "Nous chantons.",
     "parts": [
-      { "type": "segment", "role": "GS", "text": "Nous" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "PRONOUN", "text": "Nous" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "regardons" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "un film" },
+      { "type": "segment", "role": "VERB", "text": "chantons" },
       { "type": "text", "text": "." }
     ]
   },
   {
-    "id": "n1-08",
+    "id": "l1-08",
     "level": 1,
-    "text": "La maîtresse explique la leçon.",
+    "text": "Le vent souffle.",
     "parts": [
-      { "type": "segment", "role": "GS", "text": "La maîtresse" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "Le vent" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "explique" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "la leçon" },
+      { "type": "segment", "role": "VERB", "text": "souffle" },
       { "type": "text", "text": "." }
     ]
   },
   {
-    "id": "n1-09",
-    "level": 1,
-    "text": "Les lapins grignotent des carottes.",
-    "parts": [
-      { "type": "segment", "role": "GS", "text": "Les lapins" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "grignotent" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "des carottes" },
-      { "type": "text", "text": "." }
-    ]
-  },
-  {
-    "id": "n1-10",
-    "level": 1,
-    "text": "Léa dessine une maison.",
-    "parts": [
-      { "type": "segment", "role": "GS", "text": "Léa" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "dessine" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "une maison" },
-      { "type": "text", "text": "." }
-    ]
-  },
-  {
-    "id": "n1-11",
-    "level": 1,
-    "text": "Ils portent des sacs.",
-    "parts": [
-      { "type": "segment", "role": "GS", "text": "Ils" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "portent" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "des sacs" },
-      { "type": "text", "text": "." }
-    ]
-  },
-  {
-    "id": "n1-12",
-    "level": 1,
-    "text": "Le bébé touche son doudou.",
-    "parts": [
-      { "type": "segment", "role": "GS", "text": "Le bébé" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "touche" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "son doudou" },
-      { "type": "text", "text": "." }
-    ]
-  },
-  {
-    "id": "n2-01",
+    "id": "l2-01",
     "level": 2,
-    "text": "Le petit garçon porte un grand sac.",
+    "text": "La maîtresse explique la règle.",
     "parts": [
-      { "type": "segment", "role": "GS", "text": "Le petit garçon" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "La maîtresse" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "porte" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "un grand sac" },
-      { "type": "text", "text": "." }
+      { "type": "segment", "role": "VERB", "text": "explique" },
+      { "type": "text", "text": " la règle." }
     ]
   },
   {
-    "id": "n2-02",
+    "id": "l2-02",
     "level": 2,
-    "text": "La vieille cloche sonne chaque matin.",
+    "text": "Les enfants dessinent un soleil.",
     "parts": [
-      { "type": "segment", "role": "GS", "text": "La vieille cloche" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "Les enfants" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "sonne" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "chaque matin" },
-      { "type": "text", "text": "." }
+      { "type": "segment", "role": "VERB", "text": "dessinent" },
+      { "type": "text", "text": " un soleil." }
     ]
   },
   {
-    "id": "n2-03",
+    "id": "l2-03",
     "level": 2,
-    "text": "Le jardinier arrose les fleurs rouges.",
+    "text": "Le chien poursuit la balle.",
     "parts": [
-      { "type": "segment", "role": "GS", "text": "Le jardinier" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "Le chien" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "arrose" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "les fleurs rouges" },
-      { "type": "text", "text": "." }
+      { "type": "segment", "role": "VERB", "text": "poursuit" },
+      { "type": "text", "text": " la balle." }
     ]
   },
   {
-    "id": "n2-04",
+    "id": "l2-04",
     "level": 2,
-    "text": "Nous ne trouvons pas la clé.",
+    "text": "Paul regarde les nuages.",
     "parts": [
-      { "type": "segment", "role": "GS", "text": "Nous" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "Paul" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "ne trouvons pas" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "la clé" },
-      { "type": "text", "text": "." }
+      { "type": "segment", "role": "VERB", "text": "regarde" },
+      { "type": "text", "text": " les nuages." }
     ]
   },
   {
-    "id": "n2-05",
+    "id": "l2-05",
     "level": 2,
-    "text": "Les élèves rangent leurs cahiers bleus.",
+    "text": "Les parents préparent le repas.",
     "parts": [
-      { "type": "segment", "role": "GS", "text": "Les élèves" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "Les parents" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "rangent" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "leurs cahiers bleus" },
-      { "type": "text", "text": "." }
+      { "type": "segment", "role": "VERB", "text": "préparent" },
+      { "type": "text", "text": " le repas." }
     ]
   },
   {
-    "id": "n2-06",
+    "id": "l2-06",
     "level": 2,
-    "text": "Cette fillette tient une poupée douce.",
+    "text": "Nous observons les étoiles.",
     "parts": [
-      { "type": "segment", "role": "GS", "text": "Cette fillette" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "PRONOUN", "text": "Nous" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "tient" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "une poupée douce" },
-      { "type": "text", "text": "." }
+      { "type": "segment", "role": "VERB", "text": "observons" },
+      { "type": "text", "text": " les étoiles." }
     ]
   },
   {
-    "id": "n2-07",
+    "id": "l2-07",
     "level": 2,
-    "text": "Le chaton noir chasse une boule de laine.",
+    "text": "La cloche sonne la récréation.",
     "parts": [
-      { "type": "segment", "role": "GS", "text": "Le chaton noir" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "La cloche" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "chasse" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "une boule de laine" },
-      { "type": "text", "text": "." }
+      { "type": "segment", "role": "VERB", "text": "sonne" },
+      { "type": "text", "text": " la récréation." }
     ]
   },
   {
-    "id": "n2-08",
+    "id": "l2-08",
     "level": 2,
-    "text": "Vous entendez un bruit étrange.",
+    "text": "Elles terminent le puzzle.",
     "parts": [
-      { "type": "segment", "role": "GS", "text": "Vous" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "PRONOUN", "text": "Elles" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "entendez" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "un bruit étrange" },
-      { "type": "text", "text": "." }
+      { "type": "segment", "role": "VERB", "text": "terminent" },
+      { "type": "text", "text": " le puzzle." }
     ]
   },
   {
-    "id": "n2-09",
-    "level": 2,
-    "text": "Mon oncle prépare une soupe chaude.",
-    "parts": [
-      { "type": "segment", "role": "GS", "text": "Mon oncle" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "prépare" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "une soupe chaude" },
-      { "type": "text", "text": "." }
-    ]
-  },
-  {
-    "id": "n2-10",
-    "level": 2,
-    "text": "La rivière traverse un petit village.",
-    "parts": [
-      { "type": "segment", "role": "GS", "text": "La rivière" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "traverse" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "un petit village" },
-      { "type": "text", "text": "." }
-    ]
-  },
-  {
-    "id": "n2-11",
-    "level": 2,
-    "text": "Ces oiseaux ne quittent pas le nid.",
-    "parts": [
-      { "type": "segment", "role": "GS", "text": "Ces oiseaux" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "ne quittent pas" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "le nid" },
-      { "type": "text", "text": "." }
-    ]
-  },
-  {
-    "id": "n2-12",
-    "level": 2,
-    "text": "Les amies partagent un goûter sucré.",
-    "parts": [
-      { "type": "segment", "role": "GS", "text": "Les amies" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "partagent" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "un goûter sucré" },
-      { "type": "text", "text": "." }
-    ]
-  },
-  {
-    "id": "n3-01",
+    "id": "l3-01",
     "level": 3,
-    "text": "Le matin, la brume enveloppe la vallée paisible.",
+    "text": "Ils construisent un château de sable.",
     "parts": [
-      { "type": "text", "text": "Le matin, " },
-      { "type": "segment", "role": "GS", "text": "la brume" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "PRONOUN", "text": "Ils" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "enveloppe" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "la vallée paisible" },
-      { "type": "text", "text": "." }
+      { "type": "segment", "role": "VERB", "text": "construisent" },
+      { "type": "text", "text": " un château de sable." }
     ]
   },
   {
-    "id": "n3-02",
+    "id": "l3-02",
     "level": 3,
-    "text": "Sous la pluie, les coureurs accélèrent le rythme.",
+    "text": "La petite souris grignote un fromage.",
     "parts": [
-      { "type": "text", "text": "Sous la pluie, " },
-      { "type": "segment", "role": "GS", "text": "les coureurs" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "La petite souris" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "accélèrent" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "le rythme" },
-      { "type": "text", "text": "." }
+      { "type": "segment", "role": "VERB", "text": "grignote" },
+      { "type": "text", "text": " un fromage." }
     ]
   },
   {
-    "id": "n3-03",
+    "id": "l3-03",
     "level": 3,
-    "text": "Dans le grenier sombre, une araignée tisse sa toile.",
+    "text": "Tu regardes la lune.",
     "parts": [
-      { "type": "text", "text": "Dans le grenier sombre, " },
-      { "type": "segment", "role": "GS", "text": "une araignée" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "PRONOUN", "text": "Tu" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "tisse" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "sa toile" },
-      { "type": "text", "text": "." }
+      { "type": "segment", "role": "VERB", "text": "regardes" },
+      { "type": "text", "text": " la lune." }
     ]
   },
   {
-    "id": "n3-04",
+    "id": "l3-04",
     "level": 3,
-    "text": "Autour du feu, les amis racontent une histoire mystérieuse.",
+    "text": "Le grand cerf traverse la clairière.",
     "parts": [
-      { "type": "text", "text": "Autour du feu, " },
-      { "type": "segment", "role": "GS", "text": "les amis" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "Le grand cerf" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "racontent" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "une histoire mystérieuse" },
-      { "type": "text", "text": "." }
+      { "type": "segment", "role": "VERB", "text": "traverse" },
+      { "type": "text", "text": " la clairière." }
     ]
   },
   {
-    "id": "n3-05",
+    "id": "l3-05",
     "level": 3,
-    "text": "Le soir venu, la chouette observe la clairière silencieuse.",
+    "text": "Nous rangeons nos cahiers.",
     "parts": [
-      { "type": "text", "text": "Le soir venu, " },
-      { "type": "segment", "role": "GS", "text": "la chouette" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "PRONOUN", "text": "Nous" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "observe" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "la clairière silencieuse" },
-      { "type": "text", "text": "." }
+      { "type": "segment", "role": "VERB", "text": "rangeons" },
+      { "type": "text", "text": " nos cahiers." }
     ]
   },
   {
-    "id": "n3-06",
+    "id": "l3-06",
     "level": 3,
-    "text": "Près de la rivière, le castor construit un barrage solide.",
+    "text": "Les deux sœurs peignent un tableau.",
     "parts": [
-      { "type": "text", "text": "Près de la rivière, " },
-      { "type": "segment", "role": "GS", "text": "le castor" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "Les deux sœurs" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "construit" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "un barrage solide" },
-      { "type": "text", "text": "." }
+      { "type": "segment", "role": "VERB", "text": "peignent" },
+      { "type": "text", "text": " un tableau." }
     ]
   },
   {
-    "id": "n3-07",
+    "id": "l3-07",
     "level": 3,
-    "text": "Les volets fermés, la maison respire une odeur de pain chaud.",
+    "text": "Il choisit une histoire.",
     "parts": [
-      { "type": "text", "text": "Les volets fermés, " },
-      { "type": "segment", "role": "GS", "text": "la maison" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "PRONOUN", "text": "Il" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "respire" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "une odeur de pain chaud" },
-      { "type": "text", "text": "." }
+      { "type": "segment", "role": "VERB", "text": "choisit" },
+      { "type": "text", "text": " une histoire." }
     ]
   },
   {
-    "id": "n3-08",
+    "id": "l3-08",
     "level": 3,
-    "text": "Au loin, les cloches annoncent la fête du village.",
+    "text": "Les élèves attentifs écoutent le récit.",
     "parts": [
-      { "type": "text", "text": "Au loin, " },
-      { "type": "segment", "role": "GS", "text": "les cloches" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "Les élèves attentifs" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "annoncent" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "la fête du village" },
-      { "type": "text", "text": "." }
+      { "type": "segment", "role": "VERB", "text": "écoutent" },
+      { "type": "text", "text": " le récit." }
     ]
   },
   {
-    "id": "n3-09",
-    "level": 3,
-    "text": "Après le repas, les enfants découpent des formes colorées.",
-    "parts": [
-      { "type": "text", "text": "Après le repas, " },
-      { "type": "segment", "role": "GS", "text": "les enfants" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "découpent" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "des formes colorées" },
-      { "type": "text", "text": "." }
-    ]
-  },
-  {
-    "id": "n3-10",
-    "level": 3,
-    "text": "Dans la cour, une fillette observe les nuages mouvants.",
-    "parts": [
-      { "type": "text", "text": "Dans la cour, " },
-      { "type": "segment", "role": "GS", "text": "une fillette" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "observe" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "les nuages mouvants" },
-      { "type": "text", "text": "." }
-    ]
-  },
-  {
-    "id": "n3-11",
-    "level": 3,
-    "text": "Au marché du village, les marchands proposent des fruits rares.",
-    "parts": [
-      { "type": "text", "text": "Au marché du village, " },
-      { "type": "segment", "role": "GS", "text": "les marchands" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "proposent" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "des fruits rares" },
-      { "type": "text", "text": "." }
-    ]
-  },
-  {
-    "id": "n3-12",
-    "level": 3,
-    "text": "Près du port, les pêcheurs réparent leurs filets usés.",
-    "parts": [
-      { "type": "text", "text": "Près du port, " },
-      { "type": "segment", "role": "GS", "text": "les pêcheurs" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "réparent" },
-      { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "leurs filets usés" },
-      { "type": "text", "text": "." }
-    ]
-  },
-  {
-    "id": "n4-01",
+    "id": "l4-01",
     "level": 4,
-    "text": "Sous le ciel étoilé, les deux astronautes émerveillés observent la Terre bleue.",
+    "text": "Les élèves lisent dans la bibliothèque.",
     "parts": [
-      { "type": "text", "text": "Sous le ciel étoilé, " },
-      {
-        "type": "segment",
-        "role": "GS",
-        "text": "les deux astronautes émerveillés"
-      },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "Les élèves" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "observent" },
+      { "type": "segment", "role": "VERB", "text": "lisent" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "la Terre bleue" },
+      { "type": "segment", "role": "COMPLEMENT", "text": "dans la bibliothèque" },
       { "type": "text", "text": "." }
     ]
   },
   {
-    "id": "n4-02",
+    "id": "l4-02",
     "level": 4,
-    "text": "Grâce à leur courage, les trois explorateurs silencieux franchissent la rivière glacée.",
+    "text": "Le facteur passe chaque matin.",
     "parts": [
-      { "type": "text", "text": "Grâce à leur courage, " },
-      {
-        "type": "segment",
-        "role": "GS",
-        "text": "les trois explorateurs silencieux"
-      },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "Le facteur" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "franchissent" },
+      { "type": "segment", "role": "VERB", "text": "passe" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "la rivière glacée" },
+      { "type": "segment", "role": "COMPLEMENT", "text": "chaque matin" },
       { "type": "text", "text": "." }
     ]
   },
   {
-    "id": "n4-03",
+    "id": "l4-03",
     "level": 4,
-    "text": "Malgré le vent glacial, la grande montgolfière colorée emporte les voyageurs joyeux.",
+    "text": "Ma cousine joue dans le jardin.",
     "parts": [
-      { "type": "text", "text": "Malgré le vent glacial, " },
-      {
-        "type": "segment",
-        "role": "GS",
-        "text": "la grande montgolfière colorée"
-      },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "Ma cousine" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "emporte" },
+      { "type": "segment", "role": "VERB", "text": "joue" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "les voyageurs joyeux" },
+      { "type": "segment", "role": "COMPLEMENT", "text": "dans le jardin" },
       { "type": "text", "text": "." }
     ]
   },
   {
-    "id": "n4-04",
+    "id": "l4-04",
     "level": 4,
-    "text": "Au milieu du désert doré, les caravanes patientes transportent des trésors précieux.",
+    "text": "Ils déjeunent à midi.",
     "parts": [
-      { "type": "text", "text": "Au milieu du désert doré, " },
-      {
-        "type": "segment",
-        "role": "GS",
-        "text": "les caravanes patientes"
-      },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "PRONOUN", "text": "Ils" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "transportent" },
+      { "type": "segment", "role": "VERB", "text": "déjeunent" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "des trésors précieux" },
+      { "type": "segment", "role": "COMPLEMENT", "text": "à midi" },
       { "type": "text", "text": "." }
     ]
   },
   {
-    "id": "n4-05",
+    "id": "l4-05",
     "level": 4,
-    "text": "Quand la cloche résonne, toute la classe attentive range ses cahiers illustrés.",
+    "text": "Le petit train s'arrête devant la gare.",
     "parts": [
-      { "type": "text", "text": "Quand la cloche résonne, " },
-      {
-        "type": "segment",
-        "role": "GS",
-        "text": "toute la classe attentive"
-      },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "Le petit train" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "range" },
+      { "type": "segment", "role": "VERB", "text": "s'arrête" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "ses cahiers illustrés" },
+      { "type": "segment", "role": "COMPLEMENT", "text": "devant la gare" },
       { "type": "text", "text": "." }
     ]
   },
   {
-    "id": "n4-06",
+    "id": "l4-06",
     "level": 4,
-    "text": "À la tombée de la nuit, les lucioles lumineuses illuminent le sentier sinueux.",
+    "text": "Nous partons dimanche.",
     "parts": [
-      { "type": "text", "text": "À la tombée de la nuit, " },
-      {
-        "type": "segment",
-        "role": "GS",
-        "text": "les lucioles lumineuses"
-      },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "PRONOUN", "text": "Nous" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "illuminent" },
+      { "type": "segment", "role": "VERB", "text": "partons" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "le sentier sinueux" },
+      { "type": "segment", "role": "COMPLEMENT", "text": "dimanche" },
       { "type": "text", "text": "." }
     ]
   },
   {
-    "id": "n4-07",
+    "id": "l4-07",
     "level": 4,
-    "text": "Pendant l'orage, la vieille cabane tremblante protège les animaux abrités.",
+    "text": "Les hirondelles reviennent au printemps.",
     "parts": [
-      { "type": "text", "text": "Pendant l'orage, " },
-      {
-        "type": "segment",
-        "role": "GS",
-        "text": "la vieille cabane tremblante"
-      },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "Les hirondelles" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "protège" },
+      { "type": "segment", "role": "VERB", "text": "reviennent" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "les animaux abrités" },
+      { "type": "segment", "role": "COMPLEMENT", "text": "au printemps" },
       { "type": "text", "text": "." }
     ]
   },
   {
-    "id": "n4-08",
+    "id": "l4-08",
     "level": 4,
-    "text": "Dans la forêt enchantée, la chouette au plumage argenté surveille les petits aventuriers.",
+    "text": "Le spectacle commence à dix heures.",
     "parts": [
-      { "type": "text", "text": "Dans la forêt enchantée, " },
-      {
-        "type": "segment",
-        "role": "GS",
-        "text": "la chouette au plumage argenté"
-      },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "Le spectacle" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "VERBE", "text": "surveille" },
+      { "type": "segment", "role": "VERB", "text": "commence" },
       { "type": "text", "text": " " },
-      { "type": "segment", "role": "GN", "text": "les petits aventuriers" },
+      { "type": "segment", "role": "COMPLEMENT", "text": "à dix heures" },
       { "type": "text", "text": "." }
     ]
   }

--- a/data/phrases.json
+++ b/data/phrases.json
@@ -366,5 +366,109 @@
       { "type": "segment", "role": "COMPLEMENT", "text": "à dix heures" },
       { "type": "text", "text": "." }
     ]
+  },
+  {
+    "id": "l5-01",
+    "level": 5,
+    "text": "Au sommet de la colline se dressaient hier encore trois chênes majestueux.",
+    "parts": [
+      { "type": "segment", "role": "COMPLEMENT", "text": "Au sommet de la colline" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERB", "text": "se dressaient" },
+      { "type": "text", "text": " hier encore " },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "trois chênes majestueux" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "l5-02",
+    "level": 5,
+    "text": "Dans l'obscurité de la salle, chuchotait timidement une jeune actrice.",
+    "parts": [
+      { "type": "segment", "role": "COMPLEMENT", "text": "Dans l'obscurité de la salle" },
+      { "type": "text", "text": ", " },
+      { "type": "segment", "role": "VERB", "text": "chuchotait" },
+      { "type": "text", "text": " timidement " },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "une jeune actrice" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "l5-03",
+    "level": 5,
+    "text": "Arriveront-ils enfin à temps ce soir ?",
+    "parts": [
+      { "type": "segment", "role": "VERB", "text": "Arriveront" },
+      { "type": "text", "text": "-" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "PRONOUN", "text": "ils" },
+      { "type": "text", "text": " enfin à temps " },
+      { "type": "segment", "role": "COMPLEMENT", "text": "ce soir" },
+      { "type": "text", "text": " ?" }
+    ]
+  },
+  {
+    "id": "l5-04",
+    "level": 5,
+    "text": "Tout près du vieux port avaient choisi leur banc deux amis d'enfance.",
+    "parts": [
+      { "type": "segment", "role": "COMPLEMENT", "text": "Tout près du vieux port" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERB", "text": "avaient choisi" },
+      { "type": "text", "text": " leur banc " },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "deux amis d'enfance" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "l5-05",
+    "level": 5,
+    "text": "Sur la grande scène ce matin répétaient en secret les trois comédiens principaux.",
+    "parts": [
+      { "type": "segment", "role": "COMPLEMENT", "text": "Sur la grande scène ce matin" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERB", "text": "répétaient" },
+      { "type": "text", "text": " en secret " },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "les trois comédiens principaux" },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "l5-06",
+    "level": 5,
+    "text": "Parfois, écrivait-elle en cachette dans son carnet au clair de lune.",
+    "parts": [
+      { "type": "segment", "role": "COMPLEMENT", "text": "Parfois" },
+      { "type": "text", "text": ", " },
+      { "type": "segment", "role": "VERB", "text": "écrivait" },
+      { "type": "text", "text": "-" },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "PRONOUN", "text": "elle" },
+      { "type": "text", "text": " en cachette dans son carnet au clair de lune." }
+    ]
+  },
+  {
+    "id": "l5-07",
+    "level": 5,
+    "text": "Sous la tente, nous partagions encore des histoires tard dans la nuit.",
+    "parts": [
+      { "type": "segment", "role": "COMPLEMENT", "text": "Sous la tente" },
+      { "type": "text", "text": ", " },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "PRONOUN", "text": "nous" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERB", "text": "partagions" },
+      { "type": "text", "text": " encore des histoires tard dans la nuit." }
+    ]
+  },
+  {
+    "id": "l5-08",
+    "level": 5,
+    "text": "Entre les pages du vieux grimoire se cachait encore ce soir un indice mystérieux.",
+    "parts": [
+      { "type": "segment", "role": "COMPLEMENT", "text": "Entre les pages du vieux grimoire" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERB", "text": "se cachait" },
+      { "type": "text", "text": " encore ce soir " },
+      { "type": "segment", "role": "SUBJECT", "subjectType": "GN", "text": "un indice mystérieux" },
+      { "type": "text", "text": "." }
+    ]
   }
 ]

--- a/index.html
+++ b/index.html
@@ -3,13 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Repérer GS, Verbe et GN - CE2</title>
+    <title>Détective des groupes - CE2</title>
     <link rel="stylesheet" href="src/styles.css" />
   </head>
   <body>
     <header class="app-header" role="banner">
-      <h1>Repérer GS, Verbe et GN</h1>
-      <p class="tagline">Entraînement CE2 • phrase par phrase</p>
+      <h1>Détective des groupes</h1>
+      <p class="tagline">Repère le groupe sujet, le verbe et le groupe nominal !</p>
     </header>
     <main id="app" class="app" role="main">
       <section id="screen-home" class="screen active" aria-label="Accueil">
@@ -19,6 +19,7 @@
             <button class="level-btn" data-level="1">Niveau 1</button>
             <button class="level-btn" data-level="2">Niveau 2</button>
             <button class="level-btn" data-level="3">Niveau 3</button>
+            <button class="level-btn" data-level="4">Niveau 4</button>
             <button class="level-btn" data-level="all">Révision libre</button>
           </div>
           <div class="resume" id="resume-panel" aria-live="polite"></div>
@@ -28,39 +29,68 @@
         <div class="top-bar">
           <button id="back-home" class="ghost">← Accueil</button>
           <div class="scoreboard" aria-live="polite">
-            <span id="score-display">Score : 0</span>
-            <span id="streak-display">Série : 0</span>
-            <span id="best-display">Meilleur : 0</span>
+            <span class="score-pill" id="score-display">Score : 0</span>
+            <span class="score-pill" id="streak-display">Série : 0</span>
+            <span class="score-pill" id="best-display">Meilleur : 0</span>
           </div>
+          <button id="reset-progress" class="ghost small" type="button">
+            Remettre les scores à zéro
+          </button>
         </div>
         <div class="card exercise-card">
           <div class="exercise-header">
-            <div class="mode-switch" role="group" aria-label="Modes d'interaction">
-              <button class="mode-btn active" data-mode="highlight">Surlignage</button>
-              <button class="mode-btn" data-mode="drag">Drag &amp; Drop</button>
-            </div>
             <div class="icon-legend" role="list">
-              <div role="listitem" class="legend-item" data-role="GS" tabindex="0">
-                <img src="public/pictos/subject.svg" alt="Sujet" />
-                <span>GS</span>
+              <div role="listitem" class="legend-item" data-role="GS">
+                <img src="public/pictos/subject.svg" alt="Groupe sujet" />
+                <div class="legend-text">
+                  <span class="legend-title">Groupe sujet</span>
+                  <span class="legend-caption">Qui fait l'action</span>
+                </div>
               </div>
-              <div role="listitem" class="legend-item" data-role="VERBE" tabindex="0">
+              <div role="listitem" class="legend-item" data-role="VERBE">
                 <img src="public/pictos/verb.svg" alt="Verbe" />
-                <span>Verbe</span>
+                <div class="legend-text">
+                  <span class="legend-title">Verbe</span>
+                  <span class="legend-caption">Ce qui se conjugue</span>
+                </div>
               </div>
-              <div role="listitem" class="legend-item" data-role="GN" tabindex="0">
+              <div role="listitem" class="legend-item" data-role="GN">
                 <img src="public/pictos/group.svg" alt="Groupe nominal" />
-                <span>GN</span>
+                <div class="legend-text">
+                  <span class="legend-title">Groupe nominal</span>
+                  <span class="legend-caption">Complète l'action</span>
+                </div>
               </div>
             </div>
           </div>
           <div class="phrase-zone" aria-live="polite">
-            <p id="phrase-text" class="phrase" data-mode="highlight"></p>
+            <p id="phrase-text" class="phrase"></p>
           </div>
-          <div class="drag-area" aria-hidden="true">
-            <div class="drag-label" data-role="GS" draggable="false" aria-label="Étiquette Sujet">GS</div>
-            <div class="drag-label" data-role="VERBE" draggable="false" aria-label="Étiquette Verbe">Verbe</div>
-            <div class="drag-label" data-role="GN" draggable="false" aria-label="Étiquette Groupe nominal">GN</div>
+          <div class="drag-area" aria-hidden="false">
+            <div
+              class="drag-label"
+              data-role="GS"
+              draggable="false"
+              aria-label="Étiquette Groupe sujet"
+            >
+              Groupe sujet
+            </div>
+            <div
+              class="drag-label"
+              data-role="VERBE"
+              draggable="false"
+              aria-label="Étiquette Verbe"
+            >
+              Verbe
+            </div>
+            <div
+              class="drag-label"
+              data-role="GN"
+              draggable="false"
+              aria-label="Étiquette Groupe nominal"
+            >
+              Groupe nominal
+            </div>
           </div>
           <div class="help-text" id="help-text" aria-live="assertive"></div>
           <div class="controls">

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
             <button class="level-btn" data-level="2">Niveau 2</button>
             <button class="level-btn" data-level="3">Niveau 3</button>
             <button class="level-btn" data-level="4">Niveau 4</button>
+            <button class="level-btn" data-level="5">Niveau 5</button>
             <button class="level-btn" data-level="all">Révision libre</button>
           </div>
           <div class="resume" id="resume-panel" aria-live="polite"></div>
@@ -76,6 +77,25 @@
         <div class="card exercise-card">
           <div class="phrase-zone" aria-live="polite">
             <p id="phrase-text" class="phrase"></p>
+          </div>
+          <div id="subject-type-prompt" class="subject-type-prompt" hidden>
+            <p id="subject-type-question" class="prompt-question"></p>
+            <div class="prompt-body">
+              <div
+                id="subject-type-drop"
+                class="prompt-drop"
+                role="button"
+                aria-label="Dépose ta réponse ici"
+              >
+                Glisse ta réponse ici
+              </div>
+              <div
+                id="subject-type-choices"
+                class="prompt-choices"
+                role="group"
+                aria-label="Choisis la nature du sujet"
+              ></div>
+            </div>
           </div>
           <div
             class="drag-area"

--- a/index.html
+++ b/index.html
@@ -79,21 +79,10 @@
             <p id="phrase-text" class="phrase"></p>
           </div>
           <div id="subject-type-prompt" class="subject-type-prompt" hidden>
-            <button
-              id="subject-type-toggle"
-              class="prompt-toggle"
-              type="button"
-              aria-expanded="true"
-            >
-              <span id="subject-type-label" class="prompt-label">Choisis le type de sujet</span>
-              <span class="prompt-chevron" aria-hidden="true"></span>
-            </button>
-            <div id="subject-type-body" class="prompt-body">
-              <div class="prompt-question" aria-hidden="true">Choisis le type de sujet</div>
-              <div class="prompt-options" role="group" aria-label="Choisis le type de sujet">
-                <button type="button" class="prompt-option" data-subject-type="PRONOUN">Pronom</button>
-                <button type="button" class="prompt-option" data-subject-type="GN">Groupe nominal</button>
-              </div>
+            <span id="subject-type-label" class="prompt-label">Glisse le type de sujet</span>
+            <div class="prompt-options" role="group" aria-label="Type de sujet">
+              <button type="button" class="prompt-option" data-subject-type="PRONOUN">Pronom</button>
+              <button type="button" class="prompt-option" data-subject-type="GN">Groupe nominal</button>
             </div>
           </div>
           <div

--- a/index.html
+++ b/index.html
@@ -85,13 +85,12 @@
               type="button"
               aria-expanded="true"
             >
-              <span class="prompt-title">Type du sujet</span>
-              <span id="subject-type-status" class="prompt-status">À préciser</span>
+              <span id="subject-type-label" class="prompt-label">Choisis le type de sujet</span>
               <span class="prompt-chevron" aria-hidden="true"></span>
             </button>
             <div id="subject-type-body" class="prompt-body">
-              <p class="prompt-instruction">Choisis le type du sujet :</p>
-              <div class="prompt-options" role="group" aria-label="Choisis la nature du sujet">
+              <div class="prompt-question" aria-hidden="true">Choisis le type de sujet</div>
+              <div class="prompt-options" role="group" aria-label="Choisis le type de sujet">
                 <button type="button" class="prompt-option" data-subject-type="PRONOUN">Pronom</button>
                 <button type="button" class="prompt-option" data-subject-type="GN">Groupe nominal</button>
               </div>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     </header>
     <main id="app" class="app" role="main">
       <section id="screen-home" class="screen active" aria-label="Accueil">
-        <div class="card">
+        <div class="card home-card">
           <h2>Choisis ton niveau</h2>
           <div class="level-grid" role="group" aria-label="Niveaux">
             <button class="level-btn" data-level="1">Niveau 1</button>
@@ -24,21 +24,20 @@
           </div>
           <div class="resume" id="resume-panel" aria-live="polite"></div>
         </div>
-      </section>
-      <section id="screen-exercise" class="screen" aria-label="Exercice">
-        <div class="top-bar">
-          <button id="back-home" class="ghost">← Accueil</button>
-          <div class="scoreboard" aria-live="polite">
-            <span class="score-pill" id="score-display">Score : 0</span>
-            <span class="score-pill" id="streak-display">Série : 0</span>
-            <span class="score-pill" id="best-display">Meilleur : 0</span>
+        <div class="home-grid">
+          <div class="card scoreboard-card">
+            <h2>Mes scores</h2>
+            <div class="scoreboard" id="scoreboard-home" aria-live="polite">
+              <span class="score-pill" id="home-score">Score total : 0</span>
+              <span class="score-pill" id="home-best">Meilleur score : 0</span>
+              <span class="score-pill" id="home-streak">Série en cours : 0</span>
+            </div>
+            <button id="reset-progress" class="ghost small" type="button">
+              Remettre les scores à zéro
+            </button>
           </div>
-          <button id="reset-progress" class="ghost small" type="button">
-            Remettre les scores à zéro
-          </button>
-        </div>
-        <div class="card exercise-card">
-          <div class="exercise-header">
+          <div class="card legend-card">
+            <h2>Les groupes</h2>
             <div class="icon-legend" role="list">
               <div role="listitem" class="legend-item" data-role="GS">
                 <img src="public/pictos/subject.svg" alt="Groupe sujet" />
@@ -63,6 +62,14 @@
               </div>
             </div>
           </div>
+        </div>
+      </section>
+      <section id="screen-exercise" class="screen" aria-label="Exercice">
+        <div class="top-bar">
+          <button id="back-home" class="ghost back-home">← Accueil</button>
+          <span class="streak-chip" id="streak-display">Série en cours : 0</span>
+        </div>
+        <div class="card exercise-card">
           <div class="phrase-zone" aria-live="polite">
             <p id="phrase-text" class="phrase"></p>
           </div>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <body>
     <header class="app-header" role="banner">
       <h1>Détective des groupes</h1>
-      <p class="tagline">Repère le groupe sujet, le verbe et le groupe nominal !</p>
+      <p class="tagline">Repère pas à pas le groupe sujet, le verbe et les compléments !</p>
     </header>
     <main id="app" class="app" role="main">
       <section id="screen-home" class="screen active" aria-label="Accueil">
@@ -37,30 +37,34 @@
             </button>
           </div>
           <div class="card legend-card">
-            <h2>Les groupes</h2>
+            <h2>Les repères</h2>
             <div class="icon-legend" role="list">
-              <div role="listitem" class="legend-item" data-role="GS">
+              <div role="listitem" class="legend-item" data-role="SUBJECT">
                 <img src="public/pictos/subject.svg" alt="Groupe sujet" />
                 <div class="legend-text">
                   <span class="legend-title">Groupe sujet</span>
                   <span class="legend-caption">Qui fait l'action</span>
                 </div>
               </div>
-              <div role="listitem" class="legend-item" data-role="VERBE">
+              <div role="listitem" class="legend-item" data-role="VERB">
                 <img src="public/pictos/verb.svg" alt="Verbe" />
                 <div class="legend-text">
                   <span class="legend-title">Verbe</span>
                   <span class="legend-caption">Ce qui se conjugue</span>
                 </div>
               </div>
-              <div role="listitem" class="legend-item" data-role="GN">
-                <img src="public/pictos/group.svg" alt="Groupe nominal" />
+              <div role="listitem" class="legend-item" data-role="COMPLEMENT">
+                <img src="public/pictos/group.svg" alt="Complément" />
                 <div class="legend-text">
-                  <span class="legend-title">Groupe nominal</span>
-                  <span class="legend-caption">Complète l'action</span>
+                  <span class="legend-title">Complément</span>
+                  <span class="legend-caption">Lieu ou temps</span>
                 </div>
               </div>
             </div>
+            <p class="legend-note">
+              Dès le niveau 3, précise si le sujet est un <strong>pronom</strong> ou un
+              <strong>groupe nominal</strong>.
+            </p>
           </div>
         </div>
       </section>
@@ -73,32 +77,12 @@
           <div class="phrase-zone" aria-live="polite">
             <p id="phrase-text" class="phrase"></p>
           </div>
-          <div class="drag-area" aria-hidden="false">
-            <div
-              class="drag-label"
-              data-role="GS"
-              draggable="false"
-              aria-label="Étiquette Groupe sujet"
-            >
-              Groupe sujet
-            </div>
-            <div
-              class="drag-label"
-              data-role="VERBE"
-              draggable="false"
-              aria-label="Étiquette Verbe"
-            >
-              Verbe
-            </div>
-            <div
-              class="drag-label"
-              data-role="GN"
-              draggable="false"
-              aria-label="Étiquette Groupe nominal"
-            >
-              Groupe nominal
-            </div>
-          </div>
+          <div
+            class="drag-area"
+            id="drag-area"
+            role="group"
+            aria-label="Étiquettes à déplacer"
+          ></div>
           <div class="help-text" id="help-text" aria-live="assertive"></div>
           <div class="controls">
             <button id="help-btn" class="ghost">Indice</button>

--- a/index.html
+++ b/index.html
@@ -79,15 +79,23 @@
             <p id="phrase-text" class="phrase"></p>
           </div>
           <div id="subject-type-prompt" class="subject-type-prompt" hidden>
-            <div id="subject-type-drop" class="prompt-drop" role="button" aria-label="Dépose le type du sujet ici">
-              Glisse le type de sujet
+            <button
+              id="subject-type-toggle"
+              class="prompt-toggle"
+              type="button"
+              aria-expanded="true"
+            >
+              <span class="prompt-title">Type du sujet</span>
+              <span id="subject-type-status" class="prompt-status">À préciser</span>
+              <span class="prompt-chevron" aria-hidden="true"></span>
+            </button>
+            <div id="subject-type-body" class="prompt-body">
+              <p class="prompt-instruction">Choisis le type du sujet :</p>
+              <div class="prompt-options" role="group" aria-label="Choisis la nature du sujet">
+                <button type="button" class="prompt-option" data-subject-type="PRONOUN">Pronom</button>
+                <button type="button" class="prompt-option" data-subject-type="GN">Groupe nominal</button>
+              </div>
             </div>
-            <div
-              id="subject-type-choices"
-              class="prompt-choices"
-              role="group"
-              aria-label="Choisis la nature du sujet"
-            ></div>
           </div>
           <div
             class="drag-area"

--- a/index.html
+++ b/index.html
@@ -79,32 +79,15 @@
             <p id="phrase-text" class="phrase"></p>
           </div>
           <div id="subject-type-prompt" class="subject-type-prompt" hidden>
-            <button
-              id="subject-type-toggle"
-              class="prompt-toggle"
-              type="button"
-              aria-controls="subject-type-panel"
-              aria-expanded="true"
-            >
-              <span id="subject-type-question" class="prompt-question"></span>
-              <span id="subject-type-status" class="prompt-status"></span>
-            </button>
-            <div id="subject-type-panel" class="prompt-panel">
-              <div
-                id="subject-type-drop"
-                class="prompt-drop"
-                role="button"
-                aria-label="Dépose ta réponse ici"
-              >
-                Glisse ta réponse ici
-              </div>
-              <div
-                id="subject-type-choices"
-                class="prompt-choices"
-                role="group"
-                aria-label="Choisis la nature du sujet"
-              ></div>
+            <div id="subject-type-drop" class="prompt-drop" role="button" aria-label="Dépose le type du sujet ici">
+              Glisse le type de sujet
             </div>
+            <div
+              id="subject-type-choices"
+              class="prompt-choices"
+              role="group"
+              aria-label="Choisis la nature du sujet"
+            ></div>
           </div>
           <div
             class="drag-area"

--- a/index.html
+++ b/index.html
@@ -79,8 +79,17 @@
             <p id="phrase-text" class="phrase"></p>
           </div>
           <div id="subject-type-prompt" class="subject-type-prompt" hidden>
-            <p id="subject-type-question" class="prompt-question"></p>
-            <div class="prompt-body">
+            <button
+              id="subject-type-toggle"
+              class="prompt-toggle"
+              type="button"
+              aria-controls="subject-type-panel"
+              aria-expanded="true"
+            >
+              <span id="subject-type-question" class="prompt-question"></span>
+              <span id="subject-type-status" class="prompt-status"></span>
+            </button>
+            <div id="subject-type-panel" class="prompt-panel">
               <div
                 id="subject-type-drop"
                 class="prompt-drop"

--- a/src/main.js
+++ b/src/main.js
@@ -322,6 +322,7 @@ function showSubjectTypePrompt(slot) {
   const slotId = 'subject-type-slot';
   const { subjectPrompt, subjectPromptDrop, subjectPromptChoices } = elements;
   subjectPrompt.hidden = false;
+  subjectPrompt.removeAttribute('aria-hidden');
   subjectPromptDrop.textContent = 'Glisse le type de sujet';
   subjectPromptDrop.className = 'prompt-drop';
   subjectPromptDrop.dataset.slotId = slotId;
@@ -330,6 +331,7 @@ function showSubjectTypePrompt(slot) {
   subjectPromptDrop.classList.remove('assigned', 'correct', 'incorrect', 'hint');
 
   subjectPromptChoices.innerHTML = '';
+  subjectPromptChoices.removeAttribute('aria-hidden');
   ['SUBJECT_TYPE_PRONOUN', 'SUBJECT_TYPE_GN'].forEach((id) => {
     const definition = LABEL_LIBRARY[id];
     const choice = createDragLabel(definition);
@@ -357,13 +359,15 @@ function clearSubjectTypePrompt() {
   }
   const { subjectPrompt, subjectPromptDrop, subjectPromptChoices } = elements;
   subjectPrompt.hidden = true;
-  subjectPromptDrop.textContent = 'Glisse le type de sujet';
+  subjectPrompt.setAttribute('aria-hidden', 'true');
+  subjectPromptDrop.textContent = '';
   subjectPromptDrop.className = 'prompt-drop';
   subjectPromptDrop.removeAttribute('data-slot-id');
   subjectPromptDrop.removeAttribute('data-slot-type');
   subjectPromptDrop.removeAttribute('data-expected-value');
   subjectPromptDrop.classList.remove('assigned', 'correct', 'incorrect', 'hint');
   subjectPromptChoices.innerHTML = '';
+  subjectPromptChoices.setAttribute('aria-hidden', 'true');
   appState.subjectTypePrompt = null;
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -72,6 +72,7 @@ Object.values(LABEL_LIBRARY).forEach((label) => {
 const ROLE_VISUAL_CLASSES = ['role-SUBJECT', 'role-VERB', 'role-COMPLEMENT'];
 const SUBJECT_TYPE_VISUAL_CLASSES = ['subject-pronoun', 'subject-gn'];
 const SUBJECT_PROMPT_TYPE_CLASSES = ['type-PRONOUN', 'type-GN'];
+const SUBJECT_PROMPT_DEFAULT_LABEL = 'Choisis le type de sujet';
 
 const SLOT_FEEDBACK = {
   ROLE: {
@@ -132,7 +133,7 @@ const elements = {
   phraseText: document.getElementById('phrase-text'),
   subjectPrompt: document.getElementById('subject-type-prompt'),
   subjectPromptToggle: document.getElementById('subject-type-toggle'),
-  subjectPromptStatus: document.getElementById('subject-type-status'),
+  subjectPromptLabel: document.getElementById('subject-type-label'),
   subjectPromptBody: document.getElementById('subject-type-body'),
   subjectPromptOptions: Array.from(
     document.querySelectorAll('#subject-type-prompt [data-subject-type]')
@@ -374,7 +375,7 @@ function showSubjectTypePrompt(slot) {
   SUBJECT_PROMPT_TYPE_CLASSES.forEach((cls) => subjectPrompt.classList.remove(cls));
 
   appState.subjectTypePrompt = { slotId, segment: slot.element };
-  updateSubjectPromptStatus();
+  updateSubjectPromptLabel();
   updateSubjectTypeButtons(appState.subjectTypeSelection);
   setSubjectPromptExpanded(true);
 
@@ -401,7 +402,7 @@ function clearSubjectTypePrompt(options = {}) {
   SUBJECT_PROMPT_TYPE_CLASSES.forEach((cls) => subjectPrompt.classList.remove(cls));
   subjectPrompt.classList.remove('has-selection', 'collapsed', 'assigned');
   if (!preserveSelection) {
-    updateSubjectPromptStatus();
+    updateSubjectPromptLabel();
     updateSubjectTypeButtons(null);
   }
   if (elements.subjectPromptToggle) {
@@ -431,19 +432,19 @@ function setSubjectPromptExpanded(expanded) {
   }
 }
 
-function updateSubjectPromptStatus() {
-  const { subjectPrompt, subjectPromptStatus } = elements;
-  if (!subjectPrompt || !subjectPromptStatus) return;
+function updateSubjectPromptLabel() {
+  const { subjectPrompt, subjectPromptLabel } = elements;
+  if (!subjectPrompt || !subjectPromptLabel) return;
   SUBJECT_PROMPT_TYPE_CLASSES.forEach((cls) => subjectPrompt.classList.remove(cls));
   const selection = appState.subjectTypeSelection;
   subjectPrompt.classList.toggle('assigned', Boolean(selection));
   if (!selection) {
-    subjectPromptStatus.textContent = 'À préciser';
+    subjectPromptLabel.textContent = SUBJECT_PROMPT_DEFAULT_LABEL;
     subjectPrompt.classList.remove('has-selection');
     return;
   }
   const label = getLabelByKindAndValue('SUBJECT_TYPE', selection);
-  subjectPromptStatus.textContent = label ? label.text : 'Sélectionné';
+  subjectPromptLabel.textContent = label ? label.text : SUBJECT_PROMPT_DEFAULT_LABEL;
   subjectPrompt.classList.add(`type-${selection}`);
   subjectPrompt.classList.add('has-selection');
 }
@@ -466,7 +467,7 @@ function onSubjectTypeSelect(value) {
   slot.assigned = value;
   slot.element.classList.remove('incorrect', 'correct', 'hint');
   slot.element.classList.add('assigned');
-  updateSubjectPromptStatus();
+  updateSubjectPromptLabel();
   updateSubjectTypeButtons(value);
   setSubjectTypeVisual(promptState.segment, value);
   setSubjectPromptExpanded(false);
@@ -487,7 +488,7 @@ function revealHint() {
     } else if (target.kind === 'SUBJECT_TYPE') {
       target.assigned = label.value;
       appState.subjectTypeSelection = label.value;
-      updateSubjectPromptStatus();
+      updateSubjectPromptLabel();
       updateSubjectTypeButtons(label.value);
       target.element.classList.add('assigned');
       setSubjectTypeVisual(target.segment, label.value);
@@ -532,7 +533,7 @@ function onValidate() {
       if (visualType) {
         setSubjectTypeVisual(slot.segment, visualType);
       }
-      updateSubjectPromptStatus();
+      updateSubjectPromptLabel();
       updateSubjectTypeButtons(appState.subjectTypeSelection);
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -30,9 +30,10 @@ const elements = {
   levelButtons: Array.from(document.querySelectorAll('.level-btn')),
   resumePanel: document.getElementById('resume-panel'),
   backHome: document.getElementById('back-home'),
-  scoreDisplay: document.getElementById('score-display'),
+  homeScore: document.getElementById('home-score'),
+  homeBest: document.getElementById('home-best'),
+  homeStreak: document.getElementById('home-streak'),
   streakDisplay: document.getElementById('streak-display'),
-  bestDisplay: document.getElementById('best-display'),
   resetBtn: document.getElementById('reset-progress'),
   phraseText: document.getElementById('phrase-text'),
   dragArea: document.querySelector('.drag-area'),
@@ -51,11 +52,6 @@ async function init() {
   bindEvents();
   renderResume();
   updateScoreboard();
-  const { lastLevel } = appState.progress;
-  if (lastLevel) {
-    const label = lastLevel === 'all' ? 'Révision libre' : `Niveau ${lastLevel}`;
-    elements.resumePanel.textContent += ` Dernier niveau : ${label}.`;
-  }
 }
 
 async function loadData() {
@@ -124,16 +120,17 @@ function swapScreen(target) {
 }
 
 function renderResume() {
-  const { totalScore, bestScore, streak, recentPhrases } = appState.progress;
-  const lines = [
-    `Score enregistré : ${totalScore}`,
-    `Meilleur score : ${bestScore}`,
-    `Série actuelle : ${streak}`
-  ];
+  const { lastLevel, recentPhrases } = appState.progress;
+  const lines = [];
+  if (lastLevel) {
+    const label = lastLevel === 'all' ? 'Révision libre' : `Niveau ${lastLevel}`;
+    lines.push(`Dernier niveau joué : ${label}`);
+  }
   if (recentPhrases && recentPhrases.length) {
     lines.push(`Dernières phrases : ${recentPhrases.slice(0, 5).join(', ')}`);
   }
-  elements.resumePanel.textContent = lines.join(' • ');
+  elements.resumePanel.textContent =
+    lines.join(' • ') || 'Prêt à jouer ? Choisis un niveau pour commencer.';
 }
 
 function loadNextPhrase() {
@@ -164,7 +161,6 @@ function renderPhrase(phrase) {
     span.dataset.correctRole = part.role;
     span.dataset.segmentIndex = String(segmentIndex);
     span.dataset.displayRole = '';
-    span.dataset.badge = '';
     elements.phraseText.append(span);
     segmentIndex += 1;
   });
@@ -307,14 +303,22 @@ function moveGhost(ghost, clientX, clientY) {
 
 function updateScoreboard() {
   const { totalScore = 0, streak = 0, bestScore = 0 } = appState.progress;
-  elements.scoreDisplay.textContent = `Score : ${totalScore}`;
-  elements.streakDisplay.textContent = `Série : ${streak}`;
-  elements.bestDisplay.textContent = `Meilleur : ${bestScore}`;
+  if (elements.homeScore) {
+    elements.homeScore.textContent = `Score total : ${totalScore}`;
+  }
+  if (elements.homeBest) {
+    elements.homeBest.textContent = `Meilleur score : ${bestScore}`;
+  }
+  if (elements.homeStreak) {
+    elements.homeStreak.textContent = `Série en cours : ${streak}`;
+  }
+  if (elements.streakDisplay) {
+    elements.streakDisplay.textContent = `Série en cours : ${streak}`;
+  }
 }
 
 function setSegmentBadge(segment, role) {
   segment.dataset.displayRole = role || '';
-  segment.dataset.badge = role ? ROLE_LABELS[role] || role : '';
 }
 
 function onResetScores() {

--- a/src/main.js
+++ b/src/main.js
@@ -128,10 +128,6 @@ const elements = {
   resetBtn: document.getElementById('reset-progress'),
   phraseText: document.getElementById('phrase-text'),
   subjectPrompt: document.getElementById('subject-type-prompt'),
-  subjectPromptToggle: document.getElementById('subject-type-toggle'),
-  subjectPromptQuestion: document.getElementById('subject-type-question'),
-  subjectPromptStatus: document.getElementById('subject-type-status'),
-  subjectPromptPanel: document.getElementById('subject-type-panel'),
   subjectPromptDrop: document.getElementById('subject-type-drop'),
   subjectPromptChoices: document.getElementById('subject-type-choices'),
   dragArea: document.getElementById('drag-area'),
@@ -167,10 +163,6 @@ function bindEvents() {
       startSession(button.dataset.level);
     });
   });
-
-  if (elements.subjectPromptToggle) {
-    elements.subjectPromptToggle.addEventListener('click', toggleSubjectPrompt);
-  }
 
   elements.backHome.addEventListener('click', () => {
     swapScreen('home');
@@ -322,54 +314,15 @@ function createDragLabel(definition) {
   return label;
 }
 
-function updateSubjectPromptStatus(text) {
-  if (elements.subjectPromptStatus) {
-    elements.subjectPromptStatus.textContent = text || '';
-  }
-}
-
-function setSubjectPromptCollapsed(collapsed) {
-  const { subjectPrompt, subjectPromptPanel, subjectPromptToggle } = elements;
-  if (!subjectPrompt) return;
-  subjectPrompt.classList.toggle('collapsed', collapsed);
-  if (subjectPromptPanel) {
-    subjectPromptPanel.hidden = collapsed;
-  }
-  if (subjectPromptToggle) {
-    subjectPromptToggle.setAttribute('aria-expanded', String(!collapsed));
-  }
-}
-
-function toggleSubjectPrompt() {
-  const { subjectPrompt } = elements;
-  if (!subjectPrompt || subjectPrompt.hidden) return;
-  const isCollapsed = subjectPrompt.classList.contains('collapsed');
-  setSubjectPromptCollapsed(!isCollapsed);
-}
-
 function showSubjectTypePrompt(slot) {
   const expectedType = slot.subjectType;
   if (!expectedType) return;
-  const segmentText = slot.element.textContent.trim();
   clearSubjectTypePrompt();
 
   const slotId = 'subject-type-slot';
-  const {
-    subjectPrompt,
-    subjectPromptQuestion,
-    subjectPromptDrop,
-    subjectPromptChoices,
-    subjectPromptToggle
-  } = elements;
+  const { subjectPrompt, subjectPromptDrop, subjectPromptChoices } = elements;
   subjectPrompt.hidden = false;
-  subjectPromptQuestion.textContent = `Quel est le type du groupe sujet « ${segmentText} » ?`;
-  updateSubjectPromptStatus('Choisis : pronom ou groupe nominal.');
-  setSubjectPromptCollapsed(false);
-  if (subjectPromptToggle) {
-    subjectPromptToggle.focus();
-  }
-
-  subjectPromptDrop.textContent = 'Glisse ta réponse ici';
+  subjectPromptDrop.textContent = 'Glisse le type de sujet';
   subjectPromptDrop.className = 'prompt-drop';
   subjectPromptDrop.dataset.slotId = slotId;
   subjectPromptDrop.dataset.slotType = 'SUBJECT_TYPE';
@@ -402,26 +355,15 @@ function clearSubjectTypePrompt() {
     appState.slots.delete(appState.subjectTypePrompt.slotId);
     setSubjectTypeVisual(appState.subjectTypePrompt.segment, null);
   }
-  const {
-    subjectPrompt,
-    subjectPromptQuestion,
-    subjectPromptDrop,
-    subjectPromptChoices,
-    subjectPromptStatus
-  } = elements;
+  const { subjectPrompt, subjectPromptDrop, subjectPromptChoices } = elements;
   subjectPrompt.hidden = true;
-  subjectPromptQuestion.textContent = '';
-  subjectPromptDrop.textContent = 'Glisse ta réponse ici';
+  subjectPromptDrop.textContent = 'Glisse le type de sujet';
   subjectPromptDrop.className = 'prompt-drop';
   subjectPromptDrop.removeAttribute('data-slot-id');
   subjectPromptDrop.removeAttribute('data-slot-type');
   subjectPromptDrop.removeAttribute('data-expected-value');
   subjectPromptDrop.classList.remove('assigned', 'correct', 'incorrect', 'hint');
   subjectPromptChoices.innerHTML = '';
-  if (subjectPromptStatus) {
-    subjectPromptStatus.textContent = '';
-  }
-  setSubjectPromptCollapsed(false);
   appState.subjectTypePrompt = null;
 }
 
@@ -593,7 +535,7 @@ function assignToSlot(slotElement, label) {
       if (otherSlot.kind === 'ROLE') {
         setRoleVisual(otherSlot.element, null);
       } else if (otherSlot.kind === 'SUBJECT_TYPE') {
-        otherSlot.element.textContent = 'Glisse ta réponse ici';
+        otherSlot.element.textContent = 'Glisse le type de sujet';
         setSubjectTypeVisual(otherSlot.segment, null);
       }
     }
@@ -618,8 +560,6 @@ function assignToSlot(slotElement, label) {
     slot.element.textContent = label.text;
     slot.element.classList.add('assigned');
     setSubjectTypeVisual(slot.segment, label.value);
-    updateSubjectPromptStatus(`Réponse : ${label.text}. (Appuie pour modifier)`);
-    setSubjectPromptCollapsed(true);
   }
 }
 

--- a/src/storage.js
+++ b/src/storage.js
@@ -53,3 +53,9 @@ export function updateLastLevel(progress, level) {
   saveProgress(next);
   return next;
 }
+
+export function resetProgress() {
+  const next = { ...defaultState };
+  saveProgress(next);
+  return next;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -364,120 +364,44 @@ button:disabled {
 }
 
 .subject-type-prompt {
-  margin: 0.45rem auto 0.2rem;
-  padding: 0.35rem 0.5rem;
-  border-radius: calc(var(--radius) * 0.8);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(208, 232, 255, 0.92));
-  border: 1px solid rgba(39, 73, 119, 0.12);
-  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.16);
+  margin: 0.35rem auto 0.2rem;
+  padding: 0.3rem 0.55rem 0.4rem;
+  border-radius: calc(var(--radius) * 0.7);
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid rgba(42, 74, 110, 0.18);
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.14);
   display: inline-flex;
   flex-direction: column;
-  gap: 0.3rem;
-  min-width: min(100%, 260px);
+  align-items: center;
+  gap: 0.25rem;
+  min-width: min(100%, 210px);
   max-width: 100%;
-  transition: transform var(--transition), box-shadow var(--transition), padding var(--transition);
-}
-
-.subject-type-prompt.has-selection {
-  box-shadow: 0 10px 26px rgba(31, 78, 121, 0.22);
+  transition: transform var(--transition), box-shadow var(--transition);
 }
 
 .subject-type-prompt.correct {
-  box-shadow: 0 12px 30px rgba(16, 185, 129, 0.24);
+  border-color: rgba(43, 160, 120, 0.35);
+  box-shadow: 0 10px 20px rgba(16, 185, 129, 0.22);
 }
 
 .subject-type-prompt.incorrect {
-  box-shadow: 0 12px 30px rgba(239, 68, 68, 0.22);
+  border-color: rgba(222, 78, 78, 0.35);
+  box-shadow: 0 10px 20px rgba(239, 68, 68, 0.22);
 }
 
 .subject-type-prompt[hidden] {
   display: none !important;
 }
 
-.subject-type-prompt.type-PRONOUN {
-  border-color: rgba(59, 180, 197, 0.45);
-}
-
-.subject-type-prompt.type-GN {
-  border-color: rgba(242, 157, 75, 0.45);
-}
-
-.prompt-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.4rem;
-  width: 100%;
-  padding: 0.35rem 0.5rem;
-  border: none;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.92);
-  color: var(--text);
-  font-weight: 700;
-  font-size: 0.9rem;
-  letter-spacing: 0.2px;
-  cursor: pointer;
-  transition: background var(--transition), box-shadow var(--transition);
-}
-
-.subject-type-prompt.assigned .prompt-toggle {
-  background: rgba(248, 251, 255, 0.96);
-}
-
-.prompt-toggle:focus-visible {
-  outline: 2px solid var(--primary);
-  outline-offset: 2px;
-}
-
 .prompt-label {
-  font-size: 0.92rem;
-  color: rgba(33, 56, 92, 0.9);
-}
-
-.subject-type-prompt.type-PRONOUN .prompt-label {
-  color: #128294;
-}
-
-.subject-type-prompt.type-GN .prompt-label {
-  color: #c05d05;
-}
-
-.prompt-chevron {
-  position: relative;
-  width: 1rem;
-  height: 1rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  transition: transform var(--transition);
-}
-
-.prompt-chevron::before {
-  content: '▾';
-  font-size: 0.85rem;
-  color: rgba(37, 63, 98, 0.8);
-}
-
-.subject-type-prompt.collapsed .prompt-chevron {
-  transform: rotate(-90deg);
-}
-
-.prompt-body {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  padding: 0 0.15rem 0.25rem;
-}
-
-.prompt-question {
-  text-align: center;
-  font-size: 0.8rem;
-  color: rgba(42, 70, 107, 0.72);
+  font-size: 0.78rem;
+  color: rgba(28, 49, 78, 0.85);
+  font-weight: 600;
 }
 
 .prompt-options {
   display: flex;
-  gap: 0.45rem;
+  gap: 0.4rem;
   flex-wrap: wrap;
   justify-content: center;
 }
@@ -485,50 +409,38 @@ button:disabled {
 .prompt-option {
   border: none;
   border-radius: 999px;
-  padding: 0.45rem 0.9rem;
+  padding: 0.38rem 0.75rem;
   font-weight: 700;
-  font-size: 0.9rem;
+  font-size: 0.86rem;
   cursor: pointer;
-  box-shadow: 0 8px 18px rgba(31, 41, 55, 0.16);
+  box-shadow: 0 6px 14px rgba(31, 41, 55, 0.16);
   color: var(--text);
   transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
 }
 
 .prompt-option[data-subject-type='PRONOUN'] {
-  background: rgba(64, 181, 204, 0.22);
-  color: #0d5b68;
+  background: rgba(50, 167, 198, 0.22);
+  color: #0c5360;
 }
 
 .prompt-option[data-subject-type='GN'] {
-  background: rgba(247, 171, 82, 0.24);
-  color: #6f3f03;
+  background: rgba(242, 153, 67, 0.24);
+  color: #5d3603;
 }
 
 .prompt-option.active,
 .prompt-option:focus-visible {
   outline: none;
   transform: translateY(-1px);
-  box-shadow: 0 10px 22px rgba(30, 64, 175, 0.24);
+  box-shadow: 0 10px 20px rgba(30, 64, 175, 0.24);
 }
 
 .prompt-option.active[data-subject-type='PRONOUN'] {
-  background: rgba(64, 181, 204, 0.38);
+  background: rgba(50, 167, 198, 0.38);
 }
 
 .prompt-option.active[data-subject-type='GN'] {
-  background: rgba(247, 171, 82, 0.4);
-}
-
-.subject-type-prompt.collapsed {
-  padding: 0.2rem 0.4rem;
-  gap: 0.15rem;
-  min-width: auto;
-  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.16);
-}
-
-.subject-type-prompt.collapsed .prompt-toggle {
-  padding: 0.25rem 0.4rem;
-  font-size: 0.85rem;
+  background: rgba(242, 153, 67, 0.4);
 }
 
 @keyframes pop {

--- a/src/styles.css
+++ b/src/styles.css
@@ -359,6 +359,10 @@ button:disabled {
   max-width: 100%;
 }
 
+.subject-type-prompt[hidden] {
+  display: none !important;
+}
+
 .prompt-drop {
   min-height: 42px;
   min-width: min(100%, 240px);

--- a/src/styles.css
+++ b/src/styles.css
@@ -275,47 +275,17 @@ button:disabled {
   font-weight: 600;
   position: relative;
 }
-
-.segment::after {
-  content: attr(data-label-text);
-  position: absolute;
-  top: -1.25rem;
-  left: 50%;
-  transform: translate(-50%, -10%);
-  font-size: 0.72rem;
-  line-height: 1;
-  padding: 0.18rem 0.55rem;
-  border-radius: 999px;
-  color: #fff;
-  background: var(--segment-strong, rgba(76, 141, 247, 0.75));
-  opacity: 0;
-  pointer-events: none;
-  white-space: nowrap;
-  box-shadow: 0 6px 18px rgba(31, 41, 55, 0.18);
-}
-
-.segment[data-label-text='']::after {
-  display: none;
-}
-
-.segment.assigned::after,
-.segment.hint::after,
-.segment.correct::after,
-.segment.incorrect::after {
-  opacity: 1;
-}
-
-.segment[data-display-key='SUBJECT'] {
+.segment.role-SUBJECT {
   --segment-color: rgba(244, 162, 89, 0.25);
   --segment-strong: rgba(244, 162, 89, 0.72);
 }
 
-.segment[data-display-key='VERB'] {
+.segment.role-VERB {
   --segment-color: rgba(76, 141, 247, 0.22);
   --segment-strong: rgba(76, 141, 247, 0.72);
 }
 
-.segment[data-display-key='COMPLEMENT'] {
+.segment.role-COMPLEMENT {
   --segment-color: rgba(62, 201, 176, 0.24);
   --segment-strong: rgba(62, 201, 176, 0.72);
 }
@@ -323,6 +293,26 @@ button:disabled {
 .segment.assigned {
   background: var(--segment-color);
   box-shadow: 0 0 0 2px var(--segment-strong) inset;
+}
+
+.segment.subject-pronoun {
+  border-bottom: 3px solid rgba(150, 97, 255, 0.75);
+}
+
+.segment.subject-gn {
+  border-bottom: 3px solid rgba(55, 195, 161, 0.85);
+}
+
+.segment.role-SUBJECT.subject-pronoun.assigned {
+  background: rgba(150, 97, 255, 0.22);
+  box-shadow: 0 0 0 2px rgba(150, 97, 255, 0.55) inset;
+  color: #2f236d;
+}
+
+.segment.role-SUBJECT.subject-gn.assigned {
+  background: rgba(55, 195, 161, 0.22);
+  box-shadow: 0 0 0 2px rgba(55, 195, 161, 0.55) inset;
+  color: #0f4e3d;
 }
 
 .segment.readonly {
@@ -346,53 +336,80 @@ button:disabled {
   box-shadow: 0 0 0 2px var(--error) inset;
 }
 
-.type-slot {
-  display: inline-flex;
+.subject-type-prompt {
+  margin: 1rem auto 0;
+  padding: 0.85rem 1rem 1rem;
+  border-radius: calc(var(--radius) * 1.1);
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.96), rgba(227, 242, 255, 0.92));
+  border: 1px solid rgba(32, 48, 73, 0.08);
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.12);
+  max-width: 700px;
+}
+
+.prompt-question {
+  font-weight: 700;
+  text-align: center;
+  color: #1f2a44;
+  margin-bottom: 0.75rem;
+}
+
+.prompt-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.prompt-drop {
+  min-height: 52px;
+  min-width: min(100%, 320px);
+  border-radius: 16px;
+  padding: 0.65rem 1rem;
+  background: rgba(246, 248, 255, 0.75);
+  border: 2px dashed rgba(76, 141, 247, 0.45);
+  color: rgba(33, 50, 77, 0.8);
+  font-weight: 600;
+  text-align: center;
+  display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.75rem;
-  margin-left: 0.2rem;
-  padding: 0.18rem 0.6rem;
-  border-radius: 999px;
-  background: rgba(32, 48, 73, 0.08);
-  border: 1px dashed rgba(32, 48, 73, 0.25);
-  color: var(--muted);
-  transition: background var(--transition), box-shadow var(--transition), color var(--transition);
+  transition: background var(--transition), border var(--transition), color var(--transition), box-shadow var(--transition);
 }
 
-.type-slot.assigned {
+.prompt-drop.assigned {
   border-style: solid;
-  box-shadow: 0 6px 18px rgba(31, 41, 55, 0.12);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 12px 28px rgba(31, 41, 55, 0.16);
 }
 
-.type-slot[data-expected-value='PRONOUN'].assigned {
-  background: rgba(150, 97, 255, 0.25);
-  color: #4d2cb8;
-  border-color: rgba(150, 97, 255, 0.45);
+.prompt-drop.hint {
+  background: rgba(76, 141, 247, 0.18);
+  border-color: rgba(76, 141, 247, 0.6);
+  color: #1f3b6e;
 }
 
-.type-slot[data-expected-value='GN'].assigned {
-  background: rgba(55, 195, 161, 0.25);
-  color: #116954;
-  border-color: rgba(55, 195, 161, 0.45);
-}
-
-.type-slot.hint {
-  background: rgba(76, 141, 247, 0.2);
-  border-color: rgba(76, 141, 247, 0.4);
-  color: #214274;
-}
-
-.type-slot.correct {
-  background: rgba(74, 200, 160, 0.3);
+.prompt-drop.correct {
+  background: rgba(74, 200, 160, 0.25);
   border-color: rgba(74, 200, 160, 0.6);
   color: #0e6042;
 }
 
-.type-slot.incorrect {
+.prompt-drop.incorrect {
   background: rgba(240, 111, 111, 0.25);
-  border-color: rgba(240, 111, 111, 0.5);
+  border-color: rgba(240, 111, 111, 0.55);
   color: #6f1d1d;
+}
+
+.prompt-choices {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.prompt-label {
+  min-width: 140px;
+  padding: 0.6rem 1.1rem;
 }
 
 @keyframes pop {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,19 +1,19 @@
 :root {
   color-scheme: light;
   --font-base: 'Baloo 2', 'Montserrat', 'Helvetica Neue', Arial, sans-serif;
-  --bg-start: #fff4f9;
-  --bg-end: #f2f6ff;
+  --bg-start: #f3f7ff;
+  --bg-end: #ecfbf4;
   --card: #ffffff;
-  --text: #20314a;
-  --muted: #52606d;
-  --primary: #ff7a8a;
-  --primary-dark: #f25b76;
-  --accent: #4ac8a0;
-  --warning: #f2b94c;
-  --error: #ff6f6f;
-  --gs-color: #ffb347;
-  --verbe-color: #ff6f91;
-  --gn-color: #6fd3c2;
+  --text: #203049;
+  --muted: #526a7a;
+  --primary: #2d9bf0;
+  --primary-dark: #1f7cd8;
+  --accent: #4cc38a;
+  --warning: #f5b545;
+  --error: #f06f6f;
+  --gs-color: #f4a259;
+  --verbe-color: #4c8df7;
+  --gn-color: #3ec9b0;
   --radius: 18px;
   --transition: 240ms ease;
 }
@@ -37,9 +37,9 @@ body::before {
   content: '';
   position: fixed;
   inset: 0;
-  background-image: radial-gradient(circle at 15% 20%, rgba(255, 208, 236, 0.5), transparent 55%),
-    radial-gradient(circle at 85% 18%, rgba(182, 215, 255, 0.55), transparent 50%),
-    radial-gradient(circle at 30% 80%, rgba(255, 236, 179, 0.4), transparent 60%);
+  background-image: radial-gradient(circle at 15% 20%, rgba(54, 164, 255, 0.2), transparent 55%),
+    radial-gradient(circle at 80% 18%, rgba(89, 203, 173, 0.22), transparent 52%),
+    radial-gradient(circle at 28% 78%, rgba(255, 200, 110, 0.24), transparent 60%);
   pointer-events: none;
   z-index: -1;
 }
@@ -84,12 +84,26 @@ body::before {
   background: var(--card);
   border-radius: var(--radius);
   padding: clamp(1.6rem, 3vw, 2.7rem);
-  box-shadow: 0 18px 42px rgba(31, 41, 55, 0.12);
-  border: 3px solid rgba(255, 255, 255, 0.8);
+  box-shadow: 0 18px 42px rgba(27, 38, 46, 0.12);
+  border: 2px solid rgba(255, 255, 255, 0.7);
   backdrop-filter: blur(4px);
   display: flex;
   flex-direction: column;
   gap: 1.3rem;
+}
+
+.home-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.home-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 12% 20%, rgba(45, 155, 240, 0.15), transparent 65%),
+    radial-gradient(circle at 88% 30%, rgba(76, 195, 138, 0.18), transparent 70%);
+  pointer-events: none;
 }
 
 .level-grid {
@@ -113,19 +127,18 @@ button:disabled {
 }
 
 .level-btn {
-  background: linear-gradient(135deg, rgba(255, 193, 218, 0.8), rgba(194, 229, 255, 0.9));
-  color: var(--text);
+  background: linear-gradient(135deg, rgba(45, 155, 240, 0.85), rgba(62, 201, 176, 0.85));
+  color: #ffffff;
   font-weight: 700;
-  border: 2px solid rgba(255, 255, 255, 0.7);
-  box-shadow: 0 12px 24px rgba(74, 144, 226, 0.18);
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  box-shadow: 0 12px 24px rgba(45, 155, 240, 0.18);
 }
 
 .level-btn:hover,
 .level-btn:focus-visible {
-  background: linear-gradient(135deg, rgba(255, 158, 188, 0.95), rgba(161, 210, 255, 0.95));
-  color: #ffffff;
+  background: linear-gradient(135deg, rgba(31, 124, 216, 0.95), rgba(34, 160, 140, 0.95));
   transform: translateY(-3px) scale(1.01);
-  box-shadow: 0 18px 28px rgba(242, 91, 118, 0.25);
+  box-shadow: 0 18px 30px rgba(31, 124, 216, 0.25);
 }
 
 .resume {
@@ -133,17 +146,23 @@ button:disabled {
   font-size: 0.95rem;
 }
 
+.home-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.2rem;
+}
+
 .top-bar {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
 .ghost {
-  background: rgba(255, 255, 255, 0.6);
-  border: 1px solid rgba(242, 91, 118, 0.35);
+  background: rgba(255, 255, 255, 0.65);
+  border: 1px solid rgba(31, 124, 216, 0.3);
   color: var(--primary-dark);
 }
 
@@ -164,8 +183,14 @@ button:disabled {
   font-weight: 600;
 }
 
+
 .exercise-card {
-  gap: 1.5rem;
+  gap: 1.2rem;
+}
+
+.scoreboard-card h2,
+.legend-card h2 {
+  margin-bottom: 0.5rem;
 }
 
 .icon-legend {
@@ -186,8 +211,8 @@ button:disabled {
   border-radius: calc(var(--radius) * 1.2);
   cursor: default;
   border: 2px solid rgba(255, 255, 255, 0.9);
-  box-shadow: 0 12px 24px rgba(31, 41, 55, 0.12);
-  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 12px 24px rgba(27, 38, 46, 0.12);
+  background: rgba(255, 255, 255, 0.9);
   min-width: 200px;
 }
 
@@ -211,15 +236,17 @@ button:disabled {
   color: var(--muted);
 }
 
+
 .phrase-zone {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 193, 218, 0.18));
+  background: rgba(255, 255, 255, 0.96);
   border-radius: calc(var(--radius) * 0.9);
-  padding: 1.8rem;
-  min-height: 160px;
+  padding: 1.4rem 1.2rem;
+  min-height: 130px;
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 2px dashed rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(32, 48, 73, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(62, 201, 176, 0.08);
 }
 
 .phrase {
@@ -233,52 +260,27 @@ button:disabled {
 }
 
 .segment {
-  position: relative;
-  padding: 0.15rem 0.35rem;
+  padding: 0.1rem 0.35rem;
   border-radius: 10px;
   transition: background var(--transition), box-shadow var(--transition), transform var(--transition);
   font-weight: 600;
 }
 
-.segment::after {
-  content: attr(data-badge);
-  position: absolute;
-  left: 50%;
-  top: -1.6rem;
-  transform: translateX(-50%) scale(0.9);
-  background: rgba(255, 255, 255, 0.95);
-  color: var(--text);
-  padding: 0.2rem 0.55rem;
-  border-radius: 999px;
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.4px;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity var(--transition), transform var(--transition);
-  box-shadow: 0 8px 16px rgba(31, 41, 55, 0.18);
-  white-space: nowrap;
-}
-
-.segment[data-badge]::after {
-  opacity: 1;
-  transform: translateX(-50%) scale(1);
-}
-
 .segment[data-display-role='GS'] {
-  --segment-color: rgba(255, 179, 71, 0.25);
-  --segment-strong: var(--gs-color);
+  --segment-color: rgba(244, 162, 89, 0.28);
+  --segment-strong: rgba(244, 162, 89, 0.7);
 }
 
 .segment[data-display-role='VERBE'] {
-  --segment-color: rgba(255, 111, 145, 0.22);
-  --segment-strong: var(--verbe-color);
+  --segment-color: rgba(76, 141, 247, 0.22);
+  --segment-strong: rgba(76, 141, 247, 0.7);
 }
 
 .segment[data-display-role='GN'] {
-  --segment-color: rgba(111, 211, 194, 0.22);
-  --segment-strong: var(--gn-color);
+  --segment-color: rgba(62, 201, 176, 0.22);
+  --segment-strong: rgba(62, 201, 176, 0.7);
 }
+
 
 .segment.assigned {
   background: var(--segment-color);
@@ -286,8 +288,8 @@ button:disabled {
 }
 
 .segment.hint {
-  background: rgba(255, 111, 145, 0.18);
-  box-shadow: 0 0 0 2px rgba(255, 111, 145, 0.45) inset;
+  background: rgba(76, 141, 247, 0.18);
+  box-shadow: 0 0 0 2px rgba(76, 141, 247, 0.4) inset;
 }
 
 .segment.correct {
@@ -345,25 +347,25 @@ button:disabled {
   color: var(--text);
   background: rgba(255, 255, 255, 0.95);
   border: 3px solid rgba(255, 255, 255, 0.9);
-  box-shadow: 0 14px 24px rgba(31, 41, 55, 0.14);
+  box-shadow: 0 14px 24px rgba(27, 38, 46, 0.14);
   touch-action: none;
   position: relative;
   letter-spacing: 0.3px;
 }
 
 .drag-label[data-role='GS'] {
-  background: rgba(255, 179, 71, 0.2);
-  border-color: rgba(255, 179, 71, 0.45);
+  background: rgba(244, 162, 89, 0.22);
+  border-color: rgba(244, 162, 89, 0.45);
 }
 
 .drag-label[data-role='VERBE'] {
-  background: rgba(255, 111, 145, 0.2);
-  border-color: rgba(255, 111, 145, 0.45);
+  background: rgba(76, 141, 247, 0.22);
+  border-color: rgba(76, 141, 247, 0.45);
 }
 
 .drag-label[data-role='GN'] {
-  background: rgba(111, 211, 194, 0.2);
-  border-color: rgba(111, 211, 194, 0.45);
+  background: rgba(62, 201, 176, 0.22);
+  border-color: rgba(62, 201, 176, 0.45);
 }
 
 .drag-label.dragging {
@@ -395,14 +397,28 @@ button:disabled {
   justify-content: center;
 }
 
+.scoreboard-card {
+  align-self: stretch;
+}
+
+.scoreboard-card .scoreboard {
+  justify-content: flex-start;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.back-home {
+  padding: 0.45rem 0.8rem;
+}
+
 .score-pill {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
   padding: 0.45rem 0.85rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.85);
-  box-shadow: 0 8px 18px rgba(31, 41, 55, 0.12);
+  background: rgba(45, 155, 240, 0.12);
+  box-shadow: 0 8px 18px rgba(27, 38, 46, 0.12);
   font-weight: 700;
 }
 
@@ -410,20 +426,36 @@ button:disabled {
   content: '⭐';
 }
 
-#streak-display.score-pill::before {
-  content: '🔥';
-}
-
-#best-display.score-pill::before {
+#home-best.score-pill::before {
   content: '🏆';
 }
 
+#home-streak.score-pill::before {
+  content: '🔥';
+}
+
+.streak-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(45, 155, 240, 0.12);
+  color: var(--primary-dark);
+  font-weight: 600;
+  box-shadow: 0 6px 14px rgba(27, 38, 46, 0.1);
+}
+
+.streak-chip::before {
+  content: '🔥';
+}
+
 .ghost.small {
-  align-self: center;
+  align-self: flex-start;
   font-size: 0.9rem;
   padding: 0.5rem 0.85rem;
   border-radius: 999px;
-  box-shadow: 0 6px 14px rgba(242, 91, 118, 0.15);
+  box-shadow: 0 6px 14px rgba(31, 124, 216, 0.15);
 }
 
 #toast {
@@ -431,7 +463,7 @@ button:disabled {
   bottom: 1.5rem;
   left: 50%;
   transform: translateX(-50%);
-  background: linear-gradient(135deg, var(--primary) 0%, var(--verbe-color) 100%);
+  background: linear-gradient(135deg, var(--primary) 0%, var(--gn-color) 100%);
   color: white;
   padding: 0.75rem 1.2rem;
   border-radius: 999px;
@@ -466,13 +498,16 @@ button:disabled {
     font-size: 16px;
   }
 
-  .scoreboard {
-    width: 100%;
-    justify-content: space-between;
-  }
-
   .drag-label {
     min-width: 95px;
     font-size: 0.95rem;
+  }
+
+  .home-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .top-bar {
+    justify-content: space-between;
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,17 +1,21 @@
 :root {
   color-scheme: light;
-  --font-base: "Montserrat", "Helvetica Neue", Arial, sans-serif;
-  --bg: #f8fafc;
+  --font-base: 'Baloo 2', 'Montserrat', 'Helvetica Neue', Arial, sans-serif;
+  --bg-start: #fff4f9;
+  --bg-end: #f2f6ff;
   --card: #ffffff;
-  --text: #1f2933;
+  --text: #20314a;
   --muted: #52606d;
-  --primary: #4a90e2;
-  --primary-dark: #2f7ad1;
-  --accent: #27ae60;
-  --warning: #e67e22;
-  --error: #d64545;
-  --radius: 14px;
-  --transition: 220ms ease;
+  --primary: #ff7a8a;
+  --primary-dark: #f25b76;
+  --accent: #4ac8a0;
+  --warning: #f2b94c;
+  --error: #ff6f6f;
+  --gs-color: #ffb347;
+  --verbe-color: #ff6f91;
+  --gn-color: #6fd3c2;
+  --radius: 18px;
+  --transition: 240ms ease;
 }
 
 * {
@@ -21,11 +25,23 @@
 body {
   margin: 0;
   font-family: var(--font-base);
-  background: var(--bg);
+  background: linear-gradient(180deg, var(--bg-start) 0%, var(--bg-end) 100%);
   color: var(--text);
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  position: relative;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image: radial-gradient(circle at 15% 20%, rgba(255, 208, 236, 0.5), transparent 55%),
+    radial-gradient(circle at 85% 18%, rgba(182, 215, 255, 0.55), transparent 50%),
+    radial-gradient(circle at 30% 80%, rgba(255, 236, 179, 0.4), transparent 60%);
+  pointer-events: none;
+  z-index: -1;
 }
 
 .app-header,
@@ -37,13 +53,14 @@ body {
 
 .app-header h1 {
   margin: 0;
-  font-size: clamp(1.5rem, 4vw, 2.4rem);
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  letter-spacing: 0.5px;
 }
 
 .tagline {
   margin: 0.2rem 0 0;
-  color: var(--muted);
-  font-size: 0.95rem;
+  color: #3f4c5f;
+  font-size: 1rem;
 }
 
 .app {
@@ -66,11 +83,13 @@ body {
 .card {
   background: var(--card);
   border-radius: var(--radius);
-  padding: clamp(1.5rem, 3vw, 2.5rem);
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+  padding: clamp(1.6rem, 3vw, 2.7rem);
+  box-shadow: 0 18px 42px rgba(31, 41, 55, 0.12);
+  border: 3px solid rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(4px);
   display: flex;
   flex-direction: column;
-  gap: 1.2rem;
+  gap: 1.3rem;
 }
 
 .level-grid {
@@ -82,7 +101,7 @@ body {
 button {
   font: inherit;
   border: none;
-  border-radius: calc(var(--radius) / 1.6);
+  border-radius: calc(var(--radius) / 1.7);
   padding: 0.75rem 1rem;
   cursor: pointer;
   transition: transform var(--transition), background var(--transition), color var(--transition), box-shadow var(--transition);
@@ -94,17 +113,19 @@ button:disabled {
 }
 
 .level-btn {
-  background: #e3efff;
-  color: var(--primary-dark);
-  font-weight: 600;
+  background: linear-gradient(135deg, rgba(255, 193, 218, 0.8), rgba(194, 229, 255, 0.9));
+  color: var(--text);
+  font-weight: 700;
+  border: 2px solid rgba(255, 255, 255, 0.7);
+  box-shadow: 0 12px 24px rgba(74, 144, 226, 0.18);
 }
 
 .level-btn:hover,
 .level-btn:focus-visible {
-  background: var(--primary);
-  color: white;
-  transform: translateY(-2px);
-  box-shadow: 0 12px 20px rgba(74, 144, 226, 0.25);
+  background: linear-gradient(135deg, rgba(255, 158, 188, 0.95), rgba(161, 210, 255, 0.95));
+  color: #ffffff;
+  transform: translateY(-3px) scale(1.01);
+  box-shadow: 0 18px 28px rgba(242, 91, 118, 0.25);
 }
 
 .resume {
@@ -121,8 +142,8 @@ button:disabled {
 }
 
 .ghost {
-  background: transparent;
-  border: 1px solid rgba(74, 144, 226, 0.35);
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(242, 91, 118, 0.35);
   color: var(--primary-dark);
 }
 
@@ -138,8 +159,8 @@ button:disabled {
 }
 
 .secondary {
-  background: rgba(39, 174, 96, 0.15);
-  color: var(--accent);
+  background: rgba(74, 200, 160, 0.2);
+  color: #1f7f62;
   font-weight: 600;
 }
 
@@ -147,66 +168,58 @@ button:disabled {
   gap: 1.5rem;
 }
 
-.mode-switch {
-  display: flex;
-  gap: 0.75rem;
-}
-
-.mode-btn {
-  background: rgba(82, 96, 109, 0.08);
-  font-weight: 600;
-}
-
-.mode-btn.active {
-  background: var(--primary);
-  color: white;
-  box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.16);
-}
-
 .icon-legend {
   display: flex;
   gap: 1rem;
   align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
 }
 
 .legend-item {
   display: flex;
   align-items: center;
-  gap: 0.35rem;
-  font-weight: 600;
-  color: var(--muted);
-  font-size: 0.95rem;
-  padding: 0.4rem 0.6rem;
-  border-radius: 999px;
-  cursor: pointer;
-  border: 2px solid transparent;
-  transition: border var(--transition), background var(--transition), color var(--transition);
+  gap: 0.6rem;
+  color: var(--text);
+  font-size: 1rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: calc(var(--radius) * 1.2);
+  cursor: default;
+  border: 2px solid rgba(255, 255, 255, 0.9);
+  box-shadow: 0 12px 24px rgba(31, 41, 55, 0.12);
+  background: rgba(255, 255, 255, 0.85);
+  min-width: 200px;
 }
 
 .legend-item img {
-  width: 28px;
-  height: 28px;
+  width: 34px;
+  height: 34px;
 }
 
-.legend-item:focus-visible {
-  outline: none;
-  border-color: rgba(74, 144, 226, 0.4);
+.legend-text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
 }
 
-.legend-item.active {
-  background: rgba(74, 144, 226, 0.12);
-  border-color: rgba(74, 144, 226, 0.6);
-  color: var(--primary-dark);
+.legend-title {
+  font-weight: 700;
+}
+
+.legend-caption {
+  font-size: 0.85rem;
+  color: var(--muted);
 }
 
 .phrase-zone {
-  background: rgba(74, 144, 226, 0.08);
-  border-radius: calc(var(--radius) / 1.2);
-  padding: 1.5rem;
-  min-height: 140px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 193, 218, 0.18));
+  border-radius: calc(var(--radius) * 0.9);
+  padding: 1.8rem;
+  min-height: 160px;
   display: flex;
   align-items: center;
   justify-content: center;
+  border: 2px dashed rgba(255, 255, 255, 0.7);
 }
 
 .phrase {
@@ -222,23 +235,49 @@ button:disabled {
 .segment {
   position: relative;
   padding: 0.15rem 0.35rem;
-  border-radius: 8px;
+  border-radius: 10px;
   transition: background var(--transition), box-shadow var(--transition), transform var(--transition);
+  font-weight: 600;
 }
 
-.segment[data-display-role="GS"] {
-  --segment-color: rgba(74, 144, 226, 0.25);
-  --segment-strong: #4a90e2;
+.segment::after {
+  content: attr(data-badge);
+  position: absolute;
+  left: 50%;
+  top: -1.6rem;
+  transform: translateX(-50%) scale(0.9);
+  background: rgba(255, 255, 255, 0.95);
+  color: var(--text);
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition), transform var(--transition);
+  box-shadow: 0 8px 16px rgba(31, 41, 55, 0.18);
+  white-space: nowrap;
 }
 
-.segment[data-display-role="VERBE"] {
-  --segment-color: rgba(230, 126, 34, 0.22);
-  --segment-strong: #e67e22;
+.segment[data-badge]::after {
+  opacity: 1;
+  transform: translateX(-50%) scale(1);
 }
 
-.segment[data-display-role="GN"] {
-  --segment-color: rgba(39, 174, 96, 0.22);
-  --segment-strong: #27ae60;
+.segment[data-display-role='GS'] {
+  --segment-color: rgba(255, 179, 71, 0.25);
+  --segment-strong: var(--gs-color);
+}
+
+.segment[data-display-role='VERBE'] {
+  --segment-color: rgba(255, 111, 145, 0.22);
+  --segment-strong: var(--verbe-color);
+}
+
+.segment[data-display-role='GN'] {
+  --segment-color: rgba(111, 211, 194, 0.22);
+  --segment-strong: var(--gn-color);
 }
 
 .segment.assigned {
@@ -247,19 +286,19 @@ button:disabled {
 }
 
 .segment.hint {
-  background: rgba(74, 144, 226, 0.2);
-  box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.5) inset;
+  background: rgba(255, 111, 145, 0.18);
+  box-shadow: 0 0 0 2px rgba(255, 111, 145, 0.45) inset;
 }
 
 .segment.correct {
   animation: pop var(--transition);
-  background: rgba(39, 174, 96, 0.25);
+  background: rgba(74, 200, 160, 0.25);
   box-shadow: 0 0 0 2px var(--accent) inset;
 }
 
 .segment.incorrect {
   animation: shake 260ms ease;
-  background: rgba(214, 69, 69, 0.15);
+  background: rgba(255, 111, 111, 0.18);
   box-shadow: 0 0 0 2px var(--error) inset;
 }
 
@@ -293,27 +332,43 @@ button:disabled {
 .drag-area {
   display: flex;
   justify-content: center;
-  gap: 0.75rem;
+  gap: 0.9rem;
   flex-wrap: wrap;
 }
 
 .drag-label {
-  min-width: 90px;
-  padding: 0.6rem 1rem;
+  min-width: 130px;
+  padding: 0.7rem 1.2rem;
   border-radius: 999px;
   text-align: center;
-  font-weight: 600;
+  font-weight: 700;
   color: var(--text);
-  background: rgba(255, 255, 255, 0.9);
-  border: 2px solid rgba(82, 96, 109, 0.2);
-  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.1);
+  background: rgba(255, 255, 255, 0.95);
+  border: 3px solid rgba(255, 255, 255, 0.9);
+  box-shadow: 0 14px 24px rgba(31, 41, 55, 0.14);
   touch-action: none;
   position: relative;
+  letter-spacing: 0.3px;
+}
+
+.drag-label[data-role='GS'] {
+  background: rgba(255, 179, 71, 0.2);
+  border-color: rgba(255, 179, 71, 0.45);
+}
+
+.drag-label[data-role='VERBE'] {
+  background: rgba(255, 111, 145, 0.2);
+  border-color: rgba(255, 111, 145, 0.45);
+}
+
+.drag-label[data-role='GN'] {
+  background: rgba(111, 211, 194, 0.2);
+  border-color: rgba(111, 211, 194, 0.45);
 }
 
 .drag-label.dragging {
-  opacity: 0.8;
-  box-shadow: 0 14px 24px rgba(74, 144, 226, 0.32);
+  opacity: 0.85;
+  box-shadow: 0 20px 32px rgba(31, 41, 55, 0.24);
   background: var(--card);
 }
 
@@ -326,16 +381,49 @@ button:disabled {
 
 .controls {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.9rem;
   flex-wrap: wrap;
   justify-content: center;
 }
 
+
 .scoreboard {
   display: flex;
-  gap: 1rem;
+  gap: 0.75rem;
   flex-wrap: wrap;
   font-weight: 600;
+  justify-content: center;
+}
+
+.score-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 8px 18px rgba(31, 41, 55, 0.12);
+  font-weight: 700;
+}
+
+.score-pill::before {
+  content: '⭐';
+}
+
+#streak-display.score-pill::before {
+  content: '🔥';
+}
+
+#best-display.score-pill::before {
+  content: '🏆';
+}
+
+.ghost.small {
+  align-self: center;
+  font-size: 0.9rem;
+  padding: 0.5rem 0.85rem;
+  border-radius: 999px;
+  box-shadow: 0 6px 14px rgba(242, 91, 118, 0.15);
 }
 
 #toast {
@@ -343,11 +431,11 @@ button:disabled {
   bottom: 1.5rem;
   left: 50%;
   transform: translateX(-50%);
-  background: var(--text);
+  background: linear-gradient(135deg, var(--primary) 0%, var(--verbe-color) 100%);
   color: white;
   padding: 0.75rem 1.2rem;
   border-radius: 999px;
-  box-shadow: 0 12px 22px rgba(15, 23, 42, 0.25);
+  box-shadow: 0 12px 22px rgba(242, 91, 118, 0.35);
   font-size: 0.95rem;
   opacity: 0;
   pointer-events: none;
@@ -361,15 +449,15 @@ button:disabled {
 
 @media (max-width: 680px) {
   .card {
-    padding: 1.3rem;
-  }
-
-  .icon-legend {
-    flex-wrap: wrap;
+    padding: 1.4rem;
   }
 
   .phrase-zone {
-    padding: 1.1rem;
+    padding: 1.2rem;
+  }
+
+  .drag-label {
+    min-width: 110px;
   }
 }
 
@@ -383,13 +471,8 @@ button:disabled {
     justify-content: space-between;
   }
 
-  .mode-switch {
-    width: 100%;
-    justify-content: space-between;
-  }
-
   .drag-label {
-    min-width: 80px;
+    min-width: 95px;
     font-size: 0.95rem;
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -13,9 +13,9 @@
   --error: #f06f6f;
   --subject-color: #f4a259;
   --verb-color: #4c8df7;
-  --complement-color: #3ec9b0;
-  --type-pronoun: #9661ff;
-  --type-gn: #37c3a1;
+  --complement-color: #7b6bff;
+  --type-pronoun: #3bb4c5;
+  --type-gn: #f29d4b;
   --radius: 18px;
   --transition: 240ms ease;
 }
@@ -63,6 +63,14 @@ body::before {
   margin: 0.2rem 0 0;
   color: #3f4c5f;
   font-size: 1rem;
+}
+
+body.exercise-active .app-header {
+  display: none;
+}
+
+body.exercise-active .app {
+  padding-top: 0.5rem;
 }
 
 .app {
@@ -250,7 +258,7 @@ button:disabled {
   background: rgba(255, 255, 255, 0.96);
   border-radius: calc(var(--radius) * 0.9);
   padding: 1.4rem 1.2rem;
-  min-height: 130px;
+  min-height: 110px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -286,8 +294,8 @@ button:disabled {
 }
 
 .segment.role-COMPLEMENT {
-  --segment-color: rgba(62, 201, 176, 0.24);
-  --segment-strong: rgba(62, 201, 176, 0.72);
+  --segment-color: rgba(123, 107, 255, 0.22);
+  --segment-strong: rgba(123, 107, 255, 0.7);
 }
 
 .segment.assigned {
@@ -296,23 +304,23 @@ button:disabled {
 }
 
 .segment.subject-pronoun {
-  border-bottom: 3px solid rgba(150, 97, 255, 0.75);
+  border-bottom: 3px solid rgba(59, 180, 197, 0.82);
 }
 
 .segment.subject-gn {
-  border-bottom: 3px solid rgba(55, 195, 161, 0.85);
+  border-bottom: 3px solid rgba(242, 157, 75, 0.82);
 }
 
 .segment.role-SUBJECT.subject-pronoun.assigned {
-  background: rgba(150, 97, 255, 0.22);
-  box-shadow: 0 0 0 2px rgba(150, 97, 255, 0.55) inset;
-  color: #2f236d;
+  background: rgba(59, 180, 197, 0.2);
+  box-shadow: 0 0 0 2px rgba(59, 180, 197, 0.5) inset;
+  color: #0f4a50;
 }
 
 .segment.role-SUBJECT.subject-gn.assigned {
-  background: rgba(55, 195, 161, 0.22);
-  box-shadow: 0 0 0 2px rgba(55, 195, 161, 0.55) inset;
-  color: #0f4e3d;
+  background: rgba(242, 157, 75, 0.22);
+  box-shadow: 0 0 0 2px rgba(242, 157, 75, 0.55) inset;
+  color: #6d3c09;
 }
 
 .segment.readonly {
@@ -337,37 +345,79 @@ button:disabled {
 }
 
 .subject-type-prompt {
-  margin: 1rem auto 0;
-  padding: 0.85rem 1rem 1rem;
-  border-radius: calc(var(--radius) * 1.1);
-  background: linear-gradient(140deg, rgba(255, 255, 255, 0.96), rgba(227, 242, 255, 0.92));
-  border: 1px solid rgba(32, 48, 73, 0.08);
-  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.12);
-  max-width: 700px;
+  margin: 0.6rem auto 0.2rem;
+  padding: 0.55rem 0.85rem 0.7rem;
+  border-radius: calc(var(--radius) * 0.9);
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.96), rgba(217, 237, 255, 0.94));
+  border: 1px solid rgba(32, 48, 73, 0.06);
+  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.12);
+  width: min(640px, 100%);
+}
+
+.subject-type-prompt.collapsed {
+  padding-bottom: 0.45rem;
+  margin-bottom: 0.35rem;
+}
+
+.prompt-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  background: transparent;
+  padding: 0;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+}
+
+.prompt-toggle:focus-visible {
+  outline: 3px solid rgba(76, 141, 247, 0.45);
+  border-radius: calc(var(--radius) * 0.6);
+}
+
+.prompt-toggle::after {
+  content: '▾';
+  font-size: 1.1rem;
+  color: var(--primary-dark);
+  transition: transform var(--transition);
+}
+
+.subject-type-prompt.collapsed .prompt-toggle::after {
+  transform: rotate(-90deg);
 }
 
 .prompt-question {
   font-weight: 700;
-  text-align: center;
   color: #1f2a44;
-  margin-bottom: 0.75rem;
+  margin: 0;
+  font-size: 1rem;
 }
 
-.prompt-body {
+.prompt-status {
+  font-size: 0.88rem;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.prompt-panel {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65rem;
   align-items: center;
+  margin-top: 0.65rem;
 }
 
 .prompt-drop {
-  min-height: 52px;
-  min-width: min(100%, 320px);
-  border-radius: 16px;
-  padding: 0.65rem 1rem;
-  background: rgba(246, 248, 255, 0.75);
+  min-height: 48px;
+  min-width: min(100%, 300px);
+  border-radius: 14px;
+  padding: 0.55rem 0.9rem;
+  background: rgba(246, 248, 255, 0.82);
   border: 2px dashed rgba(76, 141, 247, 0.45);
-  color: rgba(33, 50, 77, 0.8);
+  color: rgba(33, 50, 77, 0.85);
   font-weight: 600;
   text-align: center;
   display: flex;
@@ -402,14 +452,14 @@ button:disabled {
 
 .prompt-choices {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.65rem;
   flex-wrap: wrap;
   justify-content: center;
 }
 
 .prompt-label {
-  min-width: 140px;
-  padding: 0.6rem 1.1rem;
+  min-width: 132px;
+  padding: 0.55rem 0.95rem;
 }
 
 @keyframes pop {
@@ -473,18 +523,18 @@ button:disabled {
 }
 
 .drag-label[data-label-id='COMPLEMENT'] {
-  background: rgba(62, 201, 176, 0.22);
-  border-color: rgba(62, 201, 176, 0.45);
+  background: rgba(123, 107, 255, 0.22);
+  border-color: rgba(123, 107, 255, 0.45);
 }
 
 .drag-label[data-label-id='SUBJECT_TYPE_PRONOUN'] {
-  background: rgba(150, 97, 255, 0.22);
-  border-color: rgba(150, 97, 255, 0.45);
+  background: rgba(59, 180, 197, 0.22);
+  border-color: rgba(59, 180, 197, 0.45);
 }
 
 .drag-label[data-label-id='SUBJECT_TYPE_GN'] {
-  background: rgba(55, 195, 161, 0.22);
-  border-color: rgba(55, 195, 161, 0.45);
+  background: rgba(242, 157, 75, 0.22);
+  border-color: rgba(242, 157, 75, 0.45);
 }
 
 .drag-label.dragging {

--- a/src/styles.css
+++ b/src/styles.css
@@ -11,9 +11,11 @@
   --accent: #4cc38a;
   --warning: #f5b545;
   --error: #f06f6f;
-  --gs-color: #f4a259;
-  --verbe-color: #4c8df7;
-  --gn-color: #3ec9b0;
+  --subject-color: #f4a259;
+  --verb-color: #4c8df7;
+  --complement-color: #3ec9b0;
+  --type-pronoun: #9661ff;
+  --type-gn: #37c3a1;
   --radius: 18px;
   --transition: 240ms ease;
 }
@@ -236,6 +238,13 @@ button:disabled {
   color: var(--muted);
 }
 
+.legend-note {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+  text-align: center;
+}
+
 
 .phrase-zone {
   background: rgba(255, 255, 255, 0.96);
@@ -261,30 +270,63 @@ button:disabled {
 
 .segment {
   padding: 0.1rem 0.35rem;
-  border-radius: 10px;
+  border-radius: 12px;
   transition: background var(--transition), box-shadow var(--transition), transform var(--transition);
   font-weight: 600;
+  position: relative;
 }
 
-.segment[data-display-role='GS'] {
-  --segment-color: rgba(244, 162, 89, 0.28);
-  --segment-strong: rgba(244, 162, 89, 0.7);
+.segment::after {
+  content: attr(data-label-text);
+  position: absolute;
+  top: -1.25rem;
+  left: 50%;
+  transform: translate(-50%, -10%);
+  font-size: 0.72rem;
+  line-height: 1;
+  padding: 0.18rem 0.55rem;
+  border-radius: 999px;
+  color: #fff;
+  background: var(--segment-strong, rgba(76, 141, 247, 0.75));
+  opacity: 0;
+  pointer-events: none;
+  white-space: nowrap;
+  box-shadow: 0 6px 18px rgba(31, 41, 55, 0.18);
 }
 
-.segment[data-display-role='VERBE'] {
+.segment[data-label-text='']::after {
+  display: none;
+}
+
+.segment.assigned::after,
+.segment.hint::after,
+.segment.correct::after,
+.segment.incorrect::after {
+  opacity: 1;
+}
+
+.segment[data-display-key='SUBJECT'] {
+  --segment-color: rgba(244, 162, 89, 0.25);
+  --segment-strong: rgba(244, 162, 89, 0.72);
+}
+
+.segment[data-display-key='VERB'] {
   --segment-color: rgba(76, 141, 247, 0.22);
-  --segment-strong: rgba(76, 141, 247, 0.7);
+  --segment-strong: rgba(76, 141, 247, 0.72);
 }
 
-.segment[data-display-role='GN'] {
-  --segment-color: rgba(62, 201, 176, 0.22);
-  --segment-strong: rgba(62, 201, 176, 0.7);
+.segment[data-display-key='COMPLEMENT'] {
+  --segment-color: rgba(62, 201, 176, 0.24);
+  --segment-strong: rgba(62, 201, 176, 0.72);
 }
-
 
 .segment.assigned {
   background: var(--segment-color);
   box-shadow: 0 0 0 2px var(--segment-strong) inset;
+}
+
+.segment.readonly {
+  opacity: 0.9;
 }
 
 .segment.hint {
@@ -302,6 +344,55 @@ button:disabled {
   animation: shake 260ms ease;
   background: rgba(255, 111, 111, 0.18);
   box-shadow: 0 0 0 2px var(--error) inset;
+}
+
+.type-slot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  margin-left: 0.2rem;
+  padding: 0.18rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(32, 48, 73, 0.08);
+  border: 1px dashed rgba(32, 48, 73, 0.25);
+  color: var(--muted);
+  transition: background var(--transition), box-shadow var(--transition), color var(--transition);
+}
+
+.type-slot.assigned {
+  border-style: solid;
+  box-shadow: 0 6px 18px rgba(31, 41, 55, 0.12);
+}
+
+.type-slot[data-expected-value='PRONOUN'].assigned {
+  background: rgba(150, 97, 255, 0.25);
+  color: #4d2cb8;
+  border-color: rgba(150, 97, 255, 0.45);
+}
+
+.type-slot[data-expected-value='GN'].assigned {
+  background: rgba(55, 195, 161, 0.25);
+  color: #116954;
+  border-color: rgba(55, 195, 161, 0.45);
+}
+
+.type-slot.hint {
+  background: rgba(76, 141, 247, 0.2);
+  border-color: rgba(76, 141, 247, 0.4);
+  color: #214274;
+}
+
+.type-slot.correct {
+  background: rgba(74, 200, 160, 0.3);
+  border-color: rgba(74, 200, 160, 0.6);
+  color: #0e6042;
+}
+
+.type-slot.incorrect {
+  background: rgba(240, 111, 111, 0.25);
+  border-color: rgba(240, 111, 111, 0.5);
+  color: #6f1d1d;
 }
 
 @keyframes pop {
@@ -351,21 +442,32 @@ button:disabled {
   touch-action: none;
   position: relative;
   letter-spacing: 0.3px;
+  user-select: none;
 }
 
-.drag-label[data-role='GS'] {
+.drag-label[data-label-id='SUBJECT'] {
   background: rgba(244, 162, 89, 0.22);
   border-color: rgba(244, 162, 89, 0.45);
 }
 
-.drag-label[data-role='VERBE'] {
+.drag-label[data-label-id='VERB'] {
   background: rgba(76, 141, 247, 0.22);
   border-color: rgba(76, 141, 247, 0.45);
 }
 
-.drag-label[data-role='GN'] {
+.drag-label[data-label-id='COMPLEMENT'] {
   background: rgba(62, 201, 176, 0.22);
   border-color: rgba(62, 201, 176, 0.45);
+}
+
+.drag-label[data-label-id='SUBJECT_TYPE_PRONOUN'] {
+  background: rgba(150, 97, 255, 0.22);
+  border-color: rgba(150, 97, 255, 0.45);
+}
+
+.drag-label[data-label-id='SUBJECT_TYPE_GN'] {
+  background: rgba(55, 195, 161, 0.22);
+  border-color: rgba(55, 195, 161, 0.45);
 }
 
 .drag-label.dragging {
@@ -374,11 +476,16 @@ button:disabled {
   background: var(--card);
 }
 
+.shake {
+  animation: shake 260ms ease;
+}
+
 .help-text {
   min-height: 1.2rem;
   text-align: center;
   color: var(--muted);
   font-size: 0.95rem;
+  line-height: 1.4;
 }
 
 .controls {

--- a/src/styles.css
+++ b/src/styles.css
@@ -282,6 +282,8 @@ button:disabled {
   transition: background var(--transition), box-shadow var(--transition), transform var(--transition);
   font-weight: 600;
   position: relative;
+  display: inline-flex;
+  align-items: center;
 }
 .segment.role-SUBJECT {
   --segment-color: rgba(244, 162, 89, 0.25);
@@ -303,12 +305,29 @@ button:disabled {
   box-shadow: 0 0 0 2px var(--segment-strong) inset;
 }
 
-.segment.subject-pronoun {
-  border-bottom: 3px solid rgba(59, 180, 197, 0.82);
+.segment::after {
+  content: '';
+  position: absolute;
+  left: 0.25rem;
+  right: 0.25rem;
+  bottom: 0.1rem;
+  height: 0.25rem;
+  border-radius: 999px;
+  opacity: 0;
+  transition: opacity var(--transition);
 }
 
-.segment.subject-gn {
-  border-bottom: 3px solid rgba(242, 157, 75, 0.82);
+.segment.subject-pronoun::after {
+  background: rgba(59, 180, 197, 0.82);
+}
+
+.segment.subject-gn::after {
+  background: rgba(242, 157, 75, 0.82);
+}
+
+.segment.subject-pronoun::after,
+.segment.subject-gn::after {
+  opacity: 1;
 }
 
 .segment.role-SUBJECT.subject-pronoun.assigned {
@@ -346,17 +365,17 @@ button:disabled {
 
 .subject-type-prompt {
   margin: 0.45rem auto 0.2rem;
-  padding: 0.4rem 0.55rem;
+  padding: 0.35rem 0.5rem;
   border-radius: calc(var(--radius) * 0.8);
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(208, 232, 255, 0.92));
   border: 1px solid rgba(39, 73, 119, 0.12);
   box-shadow: 0 8px 18px rgba(15, 23, 42, 0.16);
   display: inline-flex;
   flex-direction: column;
-  gap: 0.4rem;
-  min-width: min(100%, 290px);
+  gap: 0.3rem;
+  min-width: min(100%, 260px);
   max-width: 100%;
-  transition: transform var(--transition), box-shadow var(--transition);
+  transition: transform var(--transition), box-shadow var(--transition), padding var(--transition);
 }
 
 .subject-type-prompt.has-selection {
@@ -387,15 +406,15 @@ button:disabled {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.6rem;
+  gap: 0.4rem;
   width: 100%;
-  padding: 0.45rem 0.55rem;
+  padding: 0.35rem 0.5rem;
   border: none;
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.92);
   color: var(--text);
   font-weight: 700;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   letter-spacing: 0.2px;
   cursor: pointer;
   transition: background var(--transition), box-shadow var(--transition);
@@ -410,24 +429,16 @@ button:disabled {
   outline-offset: 2px;
 }
 
-.prompt-title {
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.4px;
-  color: rgba(37, 71, 112, 0.9);
-}
-
-.prompt-status {
-  font-size: 0.9rem;
-  font-weight: 700;
+.prompt-label {
+  font-size: 0.92rem;
   color: rgba(33, 56, 92, 0.9);
 }
 
-.subject-type-prompt.type-PRONOUN .prompt-status {
+.subject-type-prompt.type-PRONOUN .prompt-label {
   color: #128294;
 }
 
-.subject-type-prompt.type-GN .prompt-status {
+.subject-type-prompt.type-GN .prompt-label {
   color: #c05d05;
 }
 
@@ -454,20 +465,19 @@ button:disabled {
 .prompt-body {
   display: flex;
   flex-direction: column;
-  gap: 0.55rem;
-  padding: 0 0.2rem 0.25rem;
+  gap: 0.35rem;
+  padding: 0 0.15rem 0.25rem;
 }
 
-.prompt-instruction {
-  margin: 0;
-  font-size: 0.85rem;
-  color: rgba(42, 70, 107, 0.82);
+.prompt-question {
   text-align: center;
+  font-size: 0.8rem;
+  color: rgba(42, 70, 107, 0.72);
 }
 
 .prompt-options {
   display: flex;
-  gap: 0.6rem;
+  gap: 0.45rem;
   flex-wrap: wrap;
   justify-content: center;
 }
@@ -507,6 +517,18 @@ button:disabled {
 
 .prompt-option.active[data-subject-type='GN'] {
   background: rgba(247, 171, 82, 0.4);
+}
+
+.subject-type-prompt.collapsed {
+  padding: 0.2rem 0.4rem;
+  gap: 0.15rem;
+  min-width: auto;
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.16);
+}
+
+.subject-type-prompt.collapsed .prompt-toggle {
+  padding: 0.25rem 0.4rem;
+  font-size: 0.85rem;
 }
 
 @keyframes pop {

--- a/src/styles.css
+++ b/src/styles.css
@@ -345,74 +345,168 @@ button:disabled {
 }
 
 .subject-type-prompt {
-  margin: 0.5rem auto 0.25rem;
+  margin: 0.45rem auto 0.2rem;
   padding: 0.4rem 0.55rem;
   border-radius: calc(var(--radius) * 0.8);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(211, 232, 255, 0.92));
-  border: 1px solid rgba(32, 48, 73, 0.05);
-  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(208, 232, 255, 0.92));
+  border: 1px solid rgba(39, 73, 119, 0.12);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.16);
   display: inline-flex;
   flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
-  width: fit-content;
+  gap: 0.4rem;
+  min-width: min(100%, 290px);
   max-width: 100%;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.subject-type-prompt.has-selection {
+  box-shadow: 0 10px 26px rgba(31, 78, 121, 0.22);
+}
+
+.subject-type-prompt.correct {
+  box-shadow: 0 12px 30px rgba(16, 185, 129, 0.24);
+}
+
+.subject-type-prompt.incorrect {
+  box-shadow: 0 12px 30px rgba(239, 68, 68, 0.22);
 }
 
 .subject-type-prompt[hidden] {
   display: none !important;
 }
 
-.prompt-drop {
-  min-height: 42px;
-  min-width: min(100%, 240px);
-  border-radius: 12px;
-  padding: 0.45rem 0.75rem;
-  background: rgba(246, 248, 255, 0.86);
-  border: 2px dashed rgba(76, 141, 247, 0.45);
-  color: rgba(33, 50, 77, 0.85);
-  font-weight: 600;
-  text-align: center;
+.subject-type-prompt.type-PRONOUN {
+  border-color: rgba(59, 180, 197, 0.45);
+}
+
+.subject-type-prompt.type-GN {
+  border-color: rgba(242, 157, 75, 0.45);
+}
+
+.prompt-toggle {
   display: flex;
   align-items: center;
-  justify-content: center;
-  transition: background var(--transition), border var(--transition), color var(--transition), box-shadow var(--transition);
-}
-
-.prompt-drop.assigned {
-  border-style: solid;
+  justify-content: space-between;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.45rem 0.55rem;
+  border: none;
+  border-radius: 12px;
   background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 12px 28px rgba(31, 41, 55, 0.16);
+  color: var(--text);
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.2px;
+  cursor: pointer;
+  transition: background var(--transition), box-shadow var(--transition);
 }
 
-.prompt-drop.hint {
-  background: rgba(76, 141, 247, 0.18);
-  border-color: rgba(76, 141, 247, 0.6);
-  color: #1f3b6e;
+.subject-type-prompt.assigned .prompt-toggle {
+  background: rgba(248, 251, 255, 0.96);
 }
 
-.prompt-drop.correct {
-  background: rgba(74, 200, 160, 0.25);
-  border-color: rgba(74, 200, 160, 0.6);
-  color: #0e6042;
+.prompt-toggle:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
 }
 
-.prompt-drop.incorrect {
-  background: rgba(240, 111, 111, 0.25);
-  border-color: rgba(240, 111, 111, 0.55);
-  color: #6f1d1d;
+.prompt-title {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: rgba(37, 71, 112, 0.9);
 }
 
-.prompt-choices {
+.prompt-status {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: rgba(33, 56, 92, 0.9);
+}
+
+.subject-type-prompt.type-PRONOUN .prompt-status {
+  color: #128294;
+}
+
+.subject-type-prompt.type-GN .prompt-status {
+  color: #c05d05;
+}
+
+.prompt-chevron {
+  position: relative;
+  width: 1rem;
+  height: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform var(--transition);
+}
+
+.prompt-chevron::before {
+  content: '▾';
+  font-size: 0.85rem;
+  color: rgba(37, 63, 98, 0.8);
+}
+
+.subject-type-prompt.collapsed .prompt-chevron {
+  transform: rotate(-90deg);
+}
+
+.prompt-body {
   display: flex;
-  gap: 0.5rem;
+  flex-direction: column;
+  gap: 0.55rem;
+  padding: 0 0.2rem 0.25rem;
+}
+
+.prompt-instruction {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(42, 70, 107, 0.82);
+  text-align: center;
+}
+
+.prompt-options {
+  display: flex;
+  gap: 0.6rem;
   flex-wrap: wrap;
   justify-content: center;
 }
 
-.prompt-label {
-  min-width: 124px;
-  padding: 0.5rem 0.9rem;
+.prompt-option {
+  border: none;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font-weight: 700;
+  font-size: 0.9rem;
+  cursor: pointer;
+  box-shadow: 0 8px 18px rgba(31, 41, 55, 0.16);
+  color: var(--text);
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.prompt-option[data-subject-type='PRONOUN'] {
+  background: rgba(64, 181, 204, 0.22);
+  color: #0d5b68;
+}
+
+.prompt-option[data-subject-type='GN'] {
+  background: rgba(247, 171, 82, 0.24);
+  color: #6f3f03;
+}
+
+.prompt-option.active,
+.prompt-option:focus-visible {
+  outline: none;
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px rgba(30, 64, 175, 0.24);
+}
+
+.prompt-option.active[data-subject-type='PRONOUN'] {
+  background: rgba(64, 181, 204, 0.38);
+}
+
+.prompt-option.active[data-subject-type='GN'] {
+  background: rgba(247, 171, 82, 0.4);
 }
 
 @keyframes pop {

--- a/src/styles.css
+++ b/src/styles.css
@@ -345,77 +345,26 @@ button:disabled {
 }
 
 .subject-type-prompt {
-  margin: 0.6rem auto 0.2rem;
-  padding: 0.55rem 0.85rem 0.7rem;
-  border-radius: calc(var(--radius) * 0.9);
-  background: linear-gradient(140deg, rgba(255, 255, 255, 0.96), rgba(217, 237, 255, 0.94));
-  border: 1px solid rgba(32, 48, 73, 0.06);
-  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.12);
-  width: min(640px, 100%);
-}
-
-.subject-type-prompt.collapsed {
-  padding-bottom: 0.45rem;
-  margin-bottom: 0.35rem;
-}
-
-.prompt-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  width: 100%;
-  background: transparent;
-  padding: 0;
-  border: none;
-  cursor: pointer;
-  text-align: left;
-  color: inherit;
-}
-
-.prompt-toggle:focus-visible {
-  outline: 3px solid rgba(76, 141, 247, 0.45);
-  border-radius: calc(var(--radius) * 0.6);
-}
-
-.prompt-toggle::after {
-  content: '▾';
-  font-size: 1.1rem;
-  color: var(--primary-dark);
-  transition: transform var(--transition);
-}
-
-.subject-type-prompt.collapsed .prompt-toggle::after {
-  transform: rotate(-90deg);
-}
-
-.prompt-question {
-  font-weight: 700;
-  color: #1f2a44;
-  margin: 0;
-  font-size: 1rem;
-}
-
-.prompt-status {
-  font-size: 0.88rem;
-  color: var(--muted);
-  flex-shrink: 0;
-}
-
-.prompt-panel {
-  display: flex;
+  margin: 0.5rem auto 0.25rem;
+  padding: 0.4rem 0.55rem;
+  border-radius: calc(var(--radius) * 0.8);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(211, 232, 255, 0.92));
+  border: 1px solid rgba(32, 48, 73, 0.05);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
+  display: inline-flex;
   flex-direction: column;
-  gap: 0.65rem;
   align-items: center;
-  margin-top: 0.65rem;
+  gap: 0.5rem;
+  width: fit-content;
+  max-width: 100%;
 }
 
 .prompt-drop {
-  min-height: 48px;
-  min-width: min(100%, 300px);
-  border-radius: 14px;
-  padding: 0.55rem 0.9rem;
-  background: rgba(246, 248, 255, 0.82);
+  min-height: 42px;
+  min-width: min(100%, 240px);
+  border-radius: 12px;
+  padding: 0.45rem 0.75rem;
+  background: rgba(246, 248, 255, 0.86);
   border: 2px dashed rgba(76, 141, 247, 0.45);
   color: rgba(33, 50, 77, 0.85);
   font-weight: 600;
@@ -452,14 +401,14 @@ button:disabled {
 
 .prompt-choices {
   display: flex;
-  gap: 0.65rem;
+  gap: 0.5rem;
   flex-wrap: wrap;
   justify-content: center;
 }
 
 .prompt-label {
-  min-width: 132px;
-  padding: 0.55rem 0.95rem;
+  min-width: 124px;
+  padding: 0.5rem 0.9rem;
 }
 
 @keyframes pop {


### PR DESCRIPTION
## Summary
- remove the highlight mode in favour of a drag-and-drop only interaction with spelled-out group labels and a reset scores button
- refresh the kid-friendly look and feel with brighter colours, updated legend cards, and scoreboard pills
- add a new level 4 set of complex sentences for additional practice

## Testing
- no automated tests were run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d98e03496483238a15d641697d8d58