### PR TITLE
Ajoute un module mathématiques avec menu de matière

### DIFF
--- a/data/maths.json
+++ b/data/maths.json
@@ -1,0 +1,54 @@
+{
+  "level1": [
+    {
+      "id": "l1-1",
+      "question": "Tom a 28 billes. Il en gagne 15 pendant la récréation. Combien a-t-il maintenant ?",
+      "options": ["33", "43", "45"],
+      "answerIndex": 1,
+      "hint": "Additionne mentalement 28 et 15.",
+      "explanation": "28 + 15 = 43."
+    },
+    {
+      "id": "l1-2",
+      "question": "Une classe de 64 élèves part en sortie. 19 montent dans le premier bus. Combien d'élèves restent à faire monter ?",
+      "options": ["35", "45", "55"],
+      "answerIndex": 1,
+      "hint": "Soustrais 19 du nombre d'élèves de la classe.",
+      "explanation": "64 - 19 = 45, il en reste donc 45 élèves à monter."
+    },
+    {
+      "id": "l1-3",
+      "question": "Emma a 48 cartes. Elle veut les partager équitablement entre 6 amis. Combien chaque ami reçoit-il de cartes ?",
+      "options": ["6", "8", "9"],
+      "answerIndex": 1,
+      "hint": "Divise 48 en 6 parts identiques.",
+      "explanation": "48 ÷ 6 = 8."
+    }
+  ],
+  "level2": [
+    {
+      "id": "l2-1",
+      "prompt": "Complète la suite : 2, 4, 6, …",
+      "sequence": ["2", "4", "6", null],
+      "options": ["7", "8", "9"],
+      "answer": "8",
+      "hint": "On ajoute toujours 2."
+    },
+    {
+      "id": "l2-2",
+      "prompt": "Complète la suite : 5, 8, 11, …",
+      "sequence": ["5", "8", "11", null],
+      "options": ["12", "13", "14"],
+      "answer": "14",
+      "hint": "On ajoute 3 à chaque étape."
+    },
+    {
+      "id": "l2-3",
+      "prompt": "Complète la suite de formes : 🔵, 🔺, 🔵, 🔺, …",
+      "sequence": ["🔵", "🔺", "🔵", "🔺", null],
+      "options": ["🔵", "⚪", "⬛"],
+      "answer": "🔵",
+      "hint": "Les formes alternent entre le cercle bleu et le triangle rouge."
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -13,66 +13,106 @@
     </header>
     <main id="app" class="app" role="main">
       <section id="screen-home" class="screen active" aria-label="Accueil">
-        <div class="card home-card">
-          <h2>Choisis ton niveau</h2>
-          <div class="level-grid" role="group" aria-label="Niveaux">
-            <button class="level-btn" data-level="1">Niveau 1</button>
-            <button class="level-btn" data-level="2">Niveau 2</button>
-            <button class="level-btn" data-level="3">Niveau 3</button>
-            <button class="level-btn" data-level="4">Niveau 4</button>
-            <button class="level-btn" data-level="5">Niveau 5</button>
-            <button class="level-btn" data-level="all">Révision libre</button>
-          </div>
-          <div class="resume" id="resume-panel" aria-live="polite"></div>
+        <div class="subject-menu" role="tablist" aria-label="Choix de matière">
+          <button
+            class="subject-btn active"
+            data-subject="grammar"
+            role="tab"
+            aria-selected="true"
+          >
+            Grammaire
+          </button>
+          <button class="subject-btn" data-subject="math" role="tab" aria-selected="false">
+            Mathématiques
+          </button>
         </div>
-        <div class="home-grid">
-          <div class="card scoreboard-card">
-            <h2>Mes scores</h2>
-            <div class="scoreboard" id="scoreboard-home" aria-live="polite">
-              <span class="score-pill" id="home-score">Score total : 0</span>
-              <span class="score-pill" id="home-best">Meilleur score : 0</span>
-              <span class="score-pill" id="home-streak">Série en cours : 0</span>
+        <div id="grammar-panel" class="subject-panel">
+          <div class="card home-card">
+            <h2>Choisis ton niveau</h2>
+            <div class="level-grid" role="group" aria-label="Niveaux">
+              <button class="level-btn" data-level="1">Niveau 1</button>
+              <button class="level-btn" data-level="2">Niveau 2</button>
+              <button class="level-btn" data-level="3">Niveau 3</button>
+              <button class="level-btn" data-level="4">Niveau 4</button>
+              <button class="level-btn" data-level="5">Niveau 5</button>
+              <button class="level-btn" data-level="all">Révision libre</button>
             </div>
-            <div class="badge-section">
-              <h3 class="badge-heading">Badges de séries parfaites</h3>
-              <p class="badge-help" id="badge-help">
-                Joue les niveaux 3, 4 et 5 et réussis plusieurs phrases d’affilée pour débloquer les badges.
-              </p>
-              <div class="badge-grid" id="badge-grid" role="list" aria-live="polite"></div>
-            </div>
-            <button id="reset-progress" class="ghost small" type="button">
-              Remettre les scores à zéro
-            </button>
+            <div class="resume" id="resume-panel" aria-live="polite"></div>
           </div>
-          <div class="card legend-card">
-            <h2>Les repères</h2>
-            <div class="icon-legend" role="list">
-              <div role="listitem" class="legend-item" data-role="SUBJECT">
-                <img src="public/pictos/subject.svg" alt="Groupe sujet" />
-                <div class="legend-text">
-                  <span class="legend-title">Groupe sujet</span>
-                  <span class="legend-caption">Qui fait l'action</span>
-                </div>
+          <div class="home-grid">
+            <div class="card scoreboard-card">
+              <h2>Mes scores</h2>
+              <div class="scoreboard" id="scoreboard-home" aria-live="polite">
+                <span class="score-pill" id="home-score">Score total : 0</span>
+                <span class="score-pill" id="home-best">Meilleur score : 0</span>
+                <span class="score-pill" id="home-streak">Série en cours : 0</span>
               </div>
-              <div role="listitem" class="legend-item" data-role="VERB">
-                <img src="public/pictos/verb.svg" alt="Verbe" />
-                <div class="legend-text">
-                  <span class="legend-title">Verbe</span>
-                  <span class="legend-caption">Ce qui se conjugue</span>
-                </div>
+              <div class="badge-section">
+                <h3 class="badge-heading">Badges de séries parfaites</h3>
+                <p class="badge-help" id="badge-help">
+                  Joue les niveaux 3, 4 et 5 et réussis plusieurs phrases d’affilée pour débloquer les badges.
+                </p>
+                <div class="badge-grid" id="badge-grid" role="list" aria-live="polite"></div>
               </div>
-              <div role="listitem" class="legend-item" data-role="COMPLEMENT">
-                <img src="public/pictos/group.svg" alt="Complément" />
-                <div class="legend-text">
-                  <span class="legend-title">Complément</span>
-                  <span class="legend-caption">Lieu ou temps</span>
-                </div>
-              </div>
+              <button id="reset-progress" class="ghost small" type="button">
+                Remettre les scores à zéro
+              </button>
             </div>
-            <p class="legend-note">
-              Dès le niveau 3, précise si le sujet est un <strong>pronom</strong> ou un
-              <strong>groupe nominal</strong>.
+            <div class="card legend-card">
+              <h2>Les repères</h2>
+              <div class="icon-legend" role="list">
+                <div role="listitem" class="legend-item" data-role="SUBJECT">
+                  <img src="public/pictos/subject.svg" alt="Groupe sujet" />
+                  <div class="legend-text">
+                    <span class="legend-title">Groupe sujet</span>
+                    <span class="legend-caption">Qui fait l'action</span>
+                  </div>
+                </div>
+                <div role="listitem" class="legend-item" data-role="VERB">
+                  <img src="public/pictos/verb.svg" alt="Verbe" />
+                  <div class="legend-text">
+                    <span class="legend-title">Verbe</span>
+                    <span class="legend-caption">Ce qui se conjugue</span>
+                  </div>
+                </div>
+                <div role="listitem" class="legend-item" data-role="COMPLEMENT">
+                  <img src="public/pictos/group.svg" alt="Complément" />
+                  <div class="legend-text">
+                    <span class="legend-title">Complément</span>
+                    <span class="legend-caption">Lieu ou temps</span>
+                  </div>
+                </div>
+              </div>
+              <p class="legend-note">
+                Dès le niveau 3, précise si le sujet est un <strong>pronom</strong> ou un
+                <strong>groupe nominal</strong>.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div id="math-panel" class="subject-panel" hidden>
+          <div class="card home-card">
+            <h2>Choisis ton défi</h2>
+            <div class="level-grid" role="group" aria-label="Niveaux de mathématiques">
+              <button class="math-level-btn" data-math-level="1">Niveau 1 · Logique rapide</button>
+              <button class="math-level-btn" data-math-level="2">Niveau 2 · Suites logiques</button>
+            </div>
+            <p class="math-resume" id="math-resume" aria-live="polite">
+              Prêt à résoudre quelques énigmes ?
             </p>
+          </div>
+          <div class="home-grid">
+            <div class="card math-info-card">
+              <h2>Ce qui t'attend</h2>
+              <ul class="math-level-list">
+                <li><strong>Niveau 1</strong> : petits problèmes à résoudre dans ta tête avec 3 choix possibles.</li>
+                <li><strong>Niveau 2</strong> : complète la suite en glissant la bonne réponse dans la zone vide.</li>
+              </ul>
+            </div>
+            <div class="card math-score-card">
+              <h2>Mes résultats</h2>
+              <p id="math-score" class="math-score" aria-live="polite">0 réussite sur 0 exercice.</p>
+            </div>
           </div>
         </div>
       </section>
@@ -106,6 +146,27 @@
             <button id="help-btn" class="ghost">Indice</button>
             <button id="validate-btn" class="primary">Valider</button>
             <button id="next-btn" class="secondary" disabled>Suivant</button>
+          </div>
+        </div>
+      </section>
+      <section id="screen-math" class="screen" aria-label="Exercices de mathématiques">
+        <div class="top-bar">
+          <div class="top-bar-left">
+            <button id="back-home-math" class="ghost back-home">← Accueil</button>
+            <span class="app-version" aria-label="Version de l'application">v0.02</span>
+          </div>
+          <span class="streak-chip" id="math-progress">0 / 0</span>
+        </div>
+        <div class="card math-card">
+          <h2 id="math-level-title">Mathématiques</h2>
+          <p id="math-question" class="math-question" aria-live="polite"></p>
+          <div id="math-sequence" class="math-sequence" aria-live="polite"></div>
+          <div id="math-options" class="math-options" role="list"></div>
+          <div id="math-feedback" class="math-feedback" aria-live="assertive"></div>
+          <div class="controls">
+            <button id="math-hint" class="ghost">Indice</button>
+            <button id="math-validate" class="primary" disabled>Valider</button>
+            <button id="math-next" class="secondary" disabled>Suivant</button>
           </div>
         </div>
       </section>

--- a/service-worker.js
+++ b/service-worker.js
@@ -6,6 +6,7 @@ const OFFLINE_URLS = [
   'src/main.js',
   'src/storage.js',
   'data/phrases.json',
+  'data/maths.json',
   'public/pictos/subject.svg',
   'public/pictos/verb.svg',
   'public/pictos/group.svg'

--- a/src/styles.css
+++ b/src/styles.css
@@ -136,6 +136,155 @@ body.exercise-active .app {
   gap: 0.75rem;
 }
 
+.subject-menu {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.subject-btn {
+  background: rgba(255, 255, 255, 0.85);
+  border: 2px solid transparent;
+  color: var(--primary-dark);
+  font-weight: 700;
+  box-shadow: 0 10px 22px rgba(35, 110, 190, 0.12);
+}
+
+.subject-btn.active {
+  background: linear-gradient(135deg, rgba(45, 155, 240, 0.9), rgba(76, 195, 138, 0.9));
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.7);
+}
+
+.subject-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+.math-level-btn {
+  background: linear-gradient(135deg, rgba(108, 99, 255, 0.9), rgba(45, 155, 240, 0.9));
+  color: #fff;
+  font-weight: 700;
+  border: 2px solid rgba(255, 255, 255, 0.65);
+  box-shadow: 0 12px 26px rgba(64, 90, 255, 0.22);
+}
+
+.math-level-btn:hover,
+.math-level-btn:focus-visible {
+  background: linear-gradient(135deg, rgba(79, 70, 228, 1), rgba(31, 124, 216, 1));
+  transform: translateY(-3px) scale(1.01);
+}
+
+.math-resume {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.math-info-card ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.math-score {
+  font-weight: 600;
+}
+
+.math-card {
+  gap: 1rem;
+}
+
+.math-question {
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.math-sequence {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  font-size: 1.4rem;
+  justify-content: center;
+}
+
+.math-sequence .sequence-item {
+  min-width: 3rem;
+  min-height: 3rem;
+  border-radius: var(--radius);
+  border: 2px dashed rgba(45, 155, 240, 0.4);
+  background: rgba(255, 255, 255, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 0.75rem;
+  font-weight: 700;
+}
+
+.math-sequence .sequence-item.filled {
+  border-style: solid;
+  border-color: rgba(76, 195, 138, 0.7);
+  background: rgba(76, 195, 138, 0.1);
+}
+
+.math-sequence .sequence-item.drag-over {
+  border-color: rgba(45, 155, 240, 0.8);
+  background: rgba(45, 155, 240, 0.12);
+}
+
+.math-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.math-option {
+  background: rgba(45, 155, 240, 0.12);
+  border: 2px solid rgba(45, 155, 240, 0.4);
+  color: var(--primary-dark);
+  font-weight: 700;
+  padding: 0.65rem 1.2rem;
+  border-radius: calc(var(--radius) / 1.4);
+  cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.math-option:hover,
+.math-option:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(45, 155, 240, 0.2);
+}
+
+.math-option.selected {
+  background: rgba(76, 195, 138, 0.2);
+  border-color: rgba(76, 195, 138, 0.8);
+}
+
+.math-option.dragging {
+  opacity: 0.7;
+  cursor: grabbing;
+}
+
+.math-feedback {
+  min-height: 1.4rem;
+  font-weight: 600;
+  text-align: center;
+}
+
+.math-feedback.success {
+  color: var(--accent);
+}
+
+.math-feedback.error {
+  color: var(--error);
+}
+
 button {
   font: inherit;
   border: none;


### PR DESCRIPTION
## Résumé
- ajoute un menu d’accueil pour choisir entre grammaire et mathématiques
- intègre deux niveaux d’exercices de mathématiques (QCM de logique et suites à compléter en glisser-déposer)
- met à jour le style et le service worker pour les nouveaux contenus

## Tests
- Aucun test automatisé (non applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e0e4070fd4832399cb15ee571bec0a