### PR TITLE
feat: enrichir le niveau 5 et annoncer la v0.12

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Journal des versions
 
+## v0.12 · 2025-??-??
+- Ajoute des phrases inspirées des mangas japonais au niveau 5 de grammaire.
+- Met à jour la version affichée dans l'interface en v0.12.
+
 ## v0.10 · 2025-??-??
 - Met à jour la version affichée dans l'interface et les documents afin d'annoncer la release v0.10.
 

--- a/data/phrases.json
+++ b/data/phrases.json
@@ -536,5 +536,81 @@
       },
       { "type": "text", "text": "." }
     ]
+  },
+  {
+    "id": "l5-13",
+    "level": 5,
+    "text": "Sous les lanternes du festival dansait avec grâce la jeune ninja du village.",
+    "parts": [
+      { "type": "segment", "role": "COMPLEMENT", "text": "Sous les lanternes du festival" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERB", "text": "dansait" },
+      { "type": "text", "text": " avec grâce " },
+      {
+        "type": "segment",
+        "role": "SUBJECT",
+        "subjectType": "GN",
+        "text": "la jeune ninja du village"
+      },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "l5-14",
+    "level": 5,
+    "text": "Près du temple ancestral s'entraînaient chaque aube les apprentis samouraïs courageux.",
+    "parts": [
+      { "type": "segment", "role": "COMPLEMENT", "text": "Près du temple ancestral" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERB", "text": "s'entraînaient" },
+      { "type": "text", "text": " chaque aube " },
+      {
+        "type": "segment",
+        "role": "SUBJECT",
+        "subjectType": "GN",
+        "text": "les apprentis samouraïs courageux"
+      },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "l5-15",
+    "level": 5,
+    "text": "Les amis du club de dessin imaginaient hier encore des robots géants protecteurs.",
+    "parts": [
+      {
+        "type": "segment",
+        "role": "SUBJECT",
+        "subjectType": "GN",
+        "text": "Les amis du club de dessin"
+      },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERB", "text": "imaginaient" },
+      { "type": "text", "text": " hier encore " },
+      {
+        "type": "segment",
+        "role": "COMPLEMENT",
+        "text": "des robots géants protecteurs"
+      },
+      { "type": "text", "text": "." }
+    ]
+  },
+  {
+    "id": "l5-16",
+    "level": 5,
+    "text": "Au cœur de la ville futuriste résonnait soudain l'appel d'un immense mecha protecteur.",
+    "parts": [
+      { "type": "segment", "role": "COMPLEMENT", "text": "Au cœur de la ville futuriste" },
+      { "type": "text", "text": " " },
+      { "type": "segment", "role": "VERB", "text": "résonnait" },
+      { "type": "text", "text": " soudain " },
+      {
+        "type": "segment",
+        "role": "SUBJECT",
+        "subjectType": "GN",
+        "text": "l'appel d'un immense mecha protecteur"
+      },
+      { "type": "text", "text": "." }
+    ]
   }
 ]

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="src/styles.css" />
   </head>
   <body>
-    <span class="app-version app-version-floating" aria-label="Version de l'application">v0.10</span>
+    <span class="app-version app-version-floating" aria-label="Version de l'application">v0.12</span>
     <main id="app" class="app" role="main">
       <section
         id="screen-home"


### PR DESCRIPTION
## Summary
- ajoute quatre phrases inspirées des mangas japonais au niveau 5 de grammaire
- met à jour l'affichage de version de l'application vers v0.12
- documente la sortie v0.12 dans le journal des versions

## Testing
- node -e "require('./data/phrases.json')"

------
https://chatgpt.com/codex/tasks/task_e_68f7c00298b48323bdff84ecf9ee20e2